### PR TITLE
時系列SD算出時に窓内に部分ガウス関数を重みとして使用

### DIFF
--- a/scripts/01_standard_analyisis/rotation_analysis_main.py
+++ b/scripts/01_standard_analyisis/rotation_analysis_main.py
@@ -38,11 +38,11 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
 
     parser.add_argument("--day", type=str, default="test_data")
-    parser.add_argument("--fluctuation-analysis", action="store_true", help="fluctuation analysis")
+    parser.add_argument("--fluc", action="store_true", help="fluctuation analysis")
 
     args = parser.parse_args()
     day = args.day
-    flag_fluctuation_analysis = args.fluctuation_analysis
+    flag_fluctuation_analysis = args.fluc
 
     main(
         day=day,

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,90 +1,94 @@
 ## English version
+
 # Scripts directory
+
 Information about the scripts.
 
 ## 1. Setting up the environment
+
 To install the required libraries, run the following:
 ```bash
 pip3 install -r requirements.txt
 ```
 
 ## 2. Execution
-Navigate to the `scripts` directory. Execution is done via `..._main.py`.
+
+Please execute under `BactRotAnalyzer`.
 
 ### 2.1. Rotation Analysis
+
 Rotation analysis can be performed by executing the following command:<br>
 Make sure `[directory_name_to_analyze]` matches a directory name in `data`.
 
 ```bash
-python3 rotation_analysis_main.py [directory_name_to_analyze]
+python3 python3 scripts/02_compare_fluctuation_property/compare_fluctuation_main.py \
+  --days [day1] [day2] [day3] \
+  --plot-labels [label1] [label2] [label3]
+
+# example
+python3 python3 scripts/02_compare_fluctuation_property/compare_fluctuation_main.py \
+  --days SJW46_temp=10 SJW46_temp=23 SJW46_temp=30 \
+  --plot-labels 10℃ 23℃ 30℃
 ```
 
 ### 2.2. Fluctuation Analysis
+
+To perform fluctuation analysis, add the `--fluc` argument.
+
 ```bash
-python3 fluctuation_analysis_main.py [directory_name_to_analyze]
+python3 scripts/01_standard_analyisis/rotation_analysis_main.py --day [directory_name_to_analyze] --fluc
 ```
 
-## 3. About the files
-Description of the Python files used.
+### 2.3. Comparison of Fluctuation Features
 
-### 3.1. main.py
-The main file for the user to execute. By changing the arguments, the type of analysis can be modified.
+```bash
+python3 scripts/01_standard_analyisis/rotation_analysis_main.py --day [directory_name_to_analyze] --fluc
+```
 
-### 3.2. functions
-A directory containing Python files used for analysis. The functionality of each file is described below:
-- `fluctuation_analysis.py`: Performs fluctuation analysis.
-- `frequency_analysis.py`: Performs frequency analysis.
-- `get_angular_velocity.py`: Scripts related to time series angle and angular velocity. Includes obtaining, plotting, etc., of time series angle and angular velocity.
-- `get_centroid_coordinate.py`: Scripts related to centroid coordinates. Obtains, plots, and saves centroid coordinates from AVI data.
-- `input_data.py`: Handles data input.
-- `make_evaluate_switching.py`: Evaluates switching of rotation direction.
-- `make_graph.py`: Creates graphs.
-- `param.py`: Stores parameters used by many scripts.
-- `save2csv.py`: Saves data in CSV format.
+## 日本語版
 
+# スクリプトディレクトリ
 
-<br><br>
+解析スクリプトに関する情報です。
 
-## 日本語バージョン
-# Scripts directory
-スクリプトに関する情報を記載
+## 1. 環境構築
 
-## 1. 実行環境設定
-使用するライブラリのインストールのため，以下を実行．
+必要なライブラリをインストールするには以下を実行してください:
+
 ```bash
 pip3 install -r requirements.txt
 ```
 
-## 2. 実行
-`scripts`に移動する．実行は`..._main.py`により行う．
+## 2. 実行方法
+
+`BactRotAnalyzer` ディレクトリ下で実行してください。
 
 ### 2.1. 回転解析
-回転解析は，以下のように実行することで行う．<br>
-`[解析したいディレクトリ名]`は，`data`のディレクトリ名と一致するようにする．
+
+回転解析は以下のコマンドで実行できます。<br>
+`[directory_name_to_analyze]` は `data` 内のディレクトリ名に合わせてください。
 
 ```bash
-python3 ratation_analysis_main.py [解析したいディレクトリ名]
+python3 python3 scripts/02_compare_fluctuation_property/compare_fluctuation_main.py \
+  --days [day1] [day2] [day3] \
+  --plot-labels [label1] [label2] [label3]
+
+# 実行例
+python3 python3 scripts/02_compare_fluctuation_property/compare_fluctuation_main.py \
+  --days SJW46_temp=10 SJW46_temp=23 SJW46_temp=30 \
+  --plot-labels 10℃ 23℃ 30℃
 ```
 
 ### 2.2. 揺らぎ解析
+
+揺らぎ解析を行うには `--fluc` オプションを追加してください。
+
 ```bash
-python3 fluctuation_analysis_main.py [解析したいディレクトリ名]
+python3 scripts/01_standard_analyisis/rotation_analysis_main.py --day [directory_name_to_analyze] --fluc
 ```
 
-## 3. ファイルについて
-使用するPythonファイルの説明．
+### 2.3. 揺らぎ特徴の比較
 
-### 3.1. main.py
-基本的にユーザーが実行するファイル．引数を変更することで解析の種類が変更可能．
-
-### 3.2. functions
-解析にしようするPythonファイルをまとめたディレクトリ．以下ファイル別に機能を説明する．
-- `fluctuation_analysis.py`: 揺らぎ解析を行う．
-- `frequency_analysis.py`: 周波数解析を行う．
-- `get_angular_velocity.py`: 時系列角度・角速度に関するスクリプト．時系列角度・角速度の取得，プロット等を行う．
-- `get_centroid_coordinate.py`: 重心座標に係るスクリプト．AVIデータから重心座標の取得し，プロット・保存を行う．
-- `input_data.py`: データのインプットを行う．
-- `make_evaluate_switching.py`: 回転方向の切り替えの評価．
-- `make_gragh.py`: 図の作成を行う．
-- `param.py`: 多くのスクリプトで用いられるパラメータを格納．
-- `save2csv.py`: CSV形式でデータを保存する．
+```bash
+python3 scripts/01_standard_analyisis/rotation_analysis_main.py --day [directory_name_to_analyze] --fluc
+```

--- a/utils/functions/fluctuation_analysis.py
+++ b/utils/functions/fluctuation_analysis.py
@@ -18,8 +18,8 @@ def get_weights_gaussian(
     start_time: float,
     window_width: float,
     time_list: Union[Sequence[float], np.ndarray],
-    edge_peak_divisor: float = 2.0,
 ) -> np.ndarray:
+    edge_peak_divisor = param.edge_peak_divisor
     t = np.asarray(time_list, dtype=float)
 
     if t.size == 0:

--- a/utils/functions/fluctuation_analysis.py
+++ b/utils/functions/fluctuation_analysis.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from typing import List, Sequence, Tuple, Union
 
 import numpy as np
@@ -10,7 +11,6 @@ from utils.functions import (
     make_graph,
     read_csv,
     rot_df_manage,
-    save2csv,
 )
 
 
@@ -78,16 +78,24 @@ def get_sd_time_series(i, angular_velocity, day):
         }
     )
 
-    sd_list: List[List[float]] = []
-    mean_list: List[List[float]] = []
-    data_num_list: List[List[int]] = []
+    df_sd_stats_dict = defaultdict(list)
+    times = [j * time_step for j in range(int(time_list[i][-1] / time_step) + 1)]
+    df_sd_stats_dict[f"No.{i + 1}_time"] = times
+    n_time = len(times)
 
     for width_time in width_time_list:
-        add_sd = []
-        add_mean = []
         prev_mean = np.nan
         prev_sd = np.nan
-        add_data_num = []
+
+        key_sd = f"No.{i + 1}_{width_time}s_sd"
+        key_mean = f"No.{i + 1}_{width_time}s_mean"
+        key_n = f"No.{i + 1}_{width_time}s_data_num"
+
+        # record Nan from start to width_time / 2
+        start_nan_data_num = int((width_time / 2) // time_step)
+        df_sd_stats_dict[key_sd] = [np.nan] * start_nan_data_num
+        df_sd_stats_dict[key_mean] = [np.nan] * start_nan_data_num
+        df_sd_stats_dict[key_n] = [np.nan] * start_nan_data_num
 
         start_time = 0.0
         while start_time + width_time < total_time:
@@ -111,39 +119,46 @@ def get_sd_time_series(i, angular_velocity, day):
                     if np.isfinite(mean_val) and mean_val != 0.0:
                         sd_val = sd_val / mean_val
                     else:
+                        print(f"[Warning] No.{i + 1}: mean is zero or NaN, cannot compute SD/Mean.")
                         sd_val = np.nan
 
-                add_sd.append(sd_val)
-                add_mean.append(mean_val)
+                df_sd_stats_dict[key_sd].append(sd_val)
+                df_sd_stats_dict[key_mean].append(mean_val)
                 prev_sd, prev_mean = sd_val, mean_val
             else:
-                add_sd.append(prev_sd)
-                add_mean.append(prev_mean)
-            add_data_num.append(len(data))
+                df_sd_stats_dict[key_sd].append(prev_sd)
+                df_sd_stats_dict[key_mean].append(prev_mean)
+            df_sd_stats_dict[key_n].append(len(data))
             start_time += time_step
-        sd_list.append(add_sd)
-        mean_list.append(add_mean)
-        data_num_list.append(add_data_num)
 
-    return sd_list, mean_list, data_num_list
+        # record Nan until the end time
+        cur_len = len(df_sd_stats_dict[key_sd])
+        if cur_len < n_time:
+            pad = n_time - cur_len
+            df_sd_stats_dict[key_sd].extend([np.nan] * pad)
+            df_sd_stats_dict[key_mean].extend([np.nan] * pad)
+            df_sd_stats_dict[key_n].extend([np.nan] * pad)
+
+    df_sd_stats = pd.DataFrame(df_sd_stats_dict)
+
+    return df_sd_stats
 
 
-def standardize_sd_time_series(sd_list, day):
+def add_standardize_sd_to_df(df, day):
     sample_num, _, _ = param.get_config(day)
     width_time_list = param.SD_window_width_list
 
-    std_sd_list = []
     for i in range(sample_num):
-        add_std_sd_list = []
-        for j in range(len(width_time_list)):
-            sd = np.array(sd_list[i][j])
-            mean = np.mean(sd)
-            std = np.std(sd, axis=0)
+        for width_time in width_time_list:
+            key_sd = f"No.{i + 1}_{width_time}s_sd"
+            sd = np.array(df[key_sd])
+            mean = np.nanmean(sd)
+            std = np.nanstd(sd, axis=0)
             adt_sd = (sd - mean) / std
-            add_std_sd_list.append(adt_sd.tolist())
-        std_sd_list.append(add_std_sd_list)
+            key_std_sd = f"No.{i + 1}_{width_time}s_sd_std"
+            df[key_std_sd] = adt_sd
 
-    return std_sd_list
+    return df
 
 
 def evaluate_FFT(sd_freq_list, sd_Amp_list, day):
@@ -174,10 +189,6 @@ def evaluate_FFT(sd_freq_list, sd_Amp_list, day):
     # plot
     make_graph.plot_SD_FFT_feats(ratio_list, ratio_reciprocal_list, decrease_list, ref_point_list, day)
 
-    # save CSV
-    # save2csv.save_SD_FFT_decline(decrease_list, day)
-    # save2csv.save_SD_FFT_refpoints(ref_point_list, day)
-
     # save rot_df
     for j, width in enumerate(width_time_list):
         decrease_list_rot_df = []
@@ -200,53 +211,41 @@ def evaluate_FFT(sd_freq_list, sd_Amp_list, day):
 def main(angular_velocity_list, day):
     sample_num, _, _ = param.get_config(day)
     width_time_list = param.SD_window_width_list
-    sd_list = []
-    mean_list = []
-    data_num_list = []
 
+    df_list = []
     # get SD time-series
     for i in range(sample_num):
-        add_sd_list, add_mean_list, add_data_num_list = get_sd_time_series(i, angular_velocity_list[i], day)
-        sd_list.append(add_sd_list)
-        mean_list.append(add_mean_list)
-        data_num_list.append(add_data_num_list)
+        add_df = get_sd_time_series(i, angular_velocity_list[i], day)
+        df_list.append(add_df)
+    df_all = pd.concat(df_list, axis=1)
 
     # dev plot
     if param.mode_evaluate_SD_fluctuation == 0:
-        make_graph.dev_plot_av_with_mean_sd(angular_velocity_list, sd_list, mean_list, day)
-    """
-    make_graph.dev_plot_sd_data_num(data_num_list, day)
-    for j, width in enumerate(width_time_list):
-        data_num_mean_list = []
-        for i in range(sample_num):
-            data_num_mean_list.append(np.mean(data_num_list[i][j]))
-        rot_df_manage.update_rot_df(f"{ROTATION_FEATURES.SD_window_data_num_mean}_{width}s", data_num_mean_list, day)
-    """
+        make_graph.dev_plot_av_with_mean_sd(angular_velocity_list, df_all, day)
 
     # save to rot_df
-    for j, width in enumerate(width_time_list):
+    for width in width_time_list:
         sd_mean_list = []
         for i in range(sample_num):
-            sd_mean_list.append(np.mean(sd_list[i][j]))
+            sd_mean_list.append(np.nanmean(df_all[f"No.{i + 1}_{width}s_sd"]))
         rot_df_manage.update_rot_df(f"{ROTATION_FEATURES.SD_mean}_{width}s", sd_mean_list, day)
 
-    # save
-    save2csv.save_sd_time_series(sd_list, day, flag_std=False)
-
     # plot
-    flag_std = False
-    make_graph.plot_SD_list(sd_list, day, flag_std)
-    make_graph.plot_sd_mean(sd_list, day)
-    # FFT
-    # frequency_analysis.fft_sd_list(sd_list, day, flag_std)
+    make_graph.plot_SD_list(df_all, day)
+    make_graph.plot_sd_mean(df_all, day)
 
     # get standardized sd time-series
-    flag_std = True
-    std_sd_list = standardize_sd_time_series(sd_list, day)
-    save2csv.save_sd_time_series(std_sd_list, day, flag_std)
+    df_all = add_standardize_sd_to_df(df_all, day)
+    make_graph.plot_SD_list(df_all, day, flag_std=True)
 
-    make_graph.plot_SD_list(std_sd_list, day, flag_std)
-    sd_freq_list, sd_Amp_list = frequency_analysis.fft_sd_list(std_sd_list, day, flag_std)
+    # FFT
+    if param.flag_use_std_df_to_FFT:
+        sd_freq_list, sd_Amp_list = frequency_analysis.fft_sd_list(df_all, day, flag_std=True)
+    else:
+        sd_freq_list, sd_Amp_list = frequency_analysis.fft_sd_list(df_all, day, flag_std=True)
+
+    # save
+    df_all.to_csv(f"{param.save_dir_bef}/{day}/fluctuation_analysis/SD-time-series/SD_time_series.csv", index=False)
 
     if param.flag_evaluate_SD_FFT:
         evaluate_FFT(sd_freq_list, sd_Amp_list, day)

--- a/utils/functions/fluctuation_analysis.py
+++ b/utils/functions/fluctuation_analysis.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Sequence, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -14,21 +14,63 @@ from utils.functions import (
 )
 
 
+def get_weights_gaussian(
+    start_time: float,
+    window_width: float,
+    time_list: Union[Sequence[float], np.ndarray],
+    edge_peak_divisor: float = 2.0,
+) -> np.ndarray:
+    t = np.asarray(time_list, dtype=float)
+
+    if t.size == 0:
+        return np.array([], dtype=float)
+    if window_width <= 0:
+        raise ValueError("window_width must be > 0")
+    if edge_peak_divisor <= 1.0:
+        raise ValueError("edge_peak_divisor must be > 1")
+
+    center_time_sec = start_time + window_width / 2.0
+    sigma_sec = window_width / (2.0 * np.sqrt(2.0 * np.log(edge_peak_divisor)))
+
+    weights = np.exp(-0.5 * ((t - center_time_sec) / sigma_sec) ** 2)
+
+    weight_sum = weights.sum()
+    return (weights / weight_sum) if weight_sum > 0 else np.zeros_like(weights)
+
+
+def get_weighted_stats(
+    data: Union[Sequence[float], np.ndarray],
+    weights: Union[Sequence[float], np.ndarray],
+) -> Tuple[float, float]:
+    values_arr = np.asarray(data, dtype=float)
+    weights_arr = np.asarray(weights, dtype=float)
+
+    if values_arr.size == 0 or weights_arr.size == 0:
+        return np.nan, np.nan
+    if values_arr.shape != weights_arr.shape:
+        raise ValueError("`data` and `weights` must have the same shape.")
+
+    total_weight = float(np.sum(weights_arr))
+    if total_weight <= 0.0:
+        return np.nan, np.nan
+
+    normalized_weights = weights_arr / total_weight
+    weighted_mean = float(np.sum(normalized_weights * values_arr))
+    weighted_variance = float(np.sum(normalized_weights * ((values_arr - weighted_mean) ** 2)))
+    weighted_std = float(np.sqrt(weighted_variance))
+
+    return weighted_std, weighted_mean
+
+
 def get_sd_time_series(i, angular_velocity, day):
     _, FrameRate_list, total_time_list = param.get_config(day)
     width_time_list = param.SD_window_width_list
 
-    sd_list: List[List[float]] = []
-    mean_list: List[List[float]] = []
-    data_num_list: List[List[int]] = []  # develop
-
-    # Obtaining SD time-series
-    # time base
-    time_list = read_csv.get_timelist(day)
-
     time_step = 1 / FrameRate_list[i]
     total_time = float(total_time_list[i])
 
+    # time-based window
+    time_list = read_csv.get_timelist(day)
     df = pd.DataFrame(
         {
             "time": time_list[i][: len(angular_velocity)],
@@ -36,32 +78,52 @@ def get_sd_time_series(i, angular_velocity, day):
         }
     )
 
+    sd_list: List[List[float]] = []
+    mean_list: List[List[float]] = []
+    data_num_list: List[List[int]] = []
+
     for width_time in width_time_list:
         add_sd = []
-        add_mean = []  # develop
-        prev_val = np.nan
-        add_data_num = []  # develop
+        add_mean = []
+        prev_mean = np.nan
+        prev_sd = np.nan
+        add_data_num = []
 
         start_time = 0.0
         while start_time + width_time < total_time:
             mask = (df["time"] >= start_time) & (df["time"] < start_time + width_time)
-            data = df.loc[mask, "velocity"]
+            data = df.loc[mask, "velocity"].to_numpy(dtype=float)
+            times_win = df.loc[mask, "time"].to_numpy(dtype=float)
+
             if len(data) >= 3:  # at least 3 data to calculate SD
-                if param.mode_evaluate_SD_fluctuation == 0:
-                    val = data.std(ddof=1)
-                elif param.mode_evaluate_SD_fluctuation == 1:
-                    val = data.std(ddof=1) / data.mean()
-                add_sd.append(val)
-                add_mean.append(data.mean())  # develop
-                prev_val = val
+                if param.flag_apply_gaussian_window:
+                    weights = get_weights_gaussian(start_time, width_time, times_win)
+                    if weights.size == 0 or np.sum(weights) == 0:
+                        sd_val, mean_val = np.nan, np.nan
+                    else:
+                        sd_val, mean_val = get_weighted_stats(data, weights)
+                else:
+                    mean_val = float(np.mean(data))
+                    sd_val = float(np.std(data, ddof=1))
+
+                # SD/Mean
+                if param.mode_evaluate_SD_fluctuation == 1:
+                    if np.isfinite(mean_val) and mean_val != 0.0:
+                        sd_val = sd_val / mean_val
+                    else:
+                        sd_val = np.nan
+
+                add_sd.append(sd_val)
+                add_mean.append(mean_val)
+                prev_sd, prev_mean = sd_val, mean_val
             else:
-                add_mean.append(prev_val)
-                add_sd.append(prev_val)
-            add_data_num.append(len(data))  # develop
+                add_sd.append(prev_sd)
+                add_mean.append(prev_mean)
+            add_data_num.append(len(data))
             start_time += time_step
         sd_list.append(add_sd)
         mean_list.append(add_mean)
-        data_num_list.append(add_data_num)  # develop
+        data_num_list.append(add_data_num)
 
     return sd_list, mean_list, data_num_list
 
@@ -139,8 +201,8 @@ def main(angular_velocity_list, day):
     sample_num, _, _ = param.get_config(day)
     width_time_list = param.SD_window_width_list
     sd_list = []
-    mean_list = []  # develop
-    data_num_list = []  # develop
+    mean_list = []
+    data_num_list = []
 
     # get SD time-series
     for i in range(sample_num):
@@ -153,7 +215,7 @@ def main(angular_velocity_list, day):
     if param.mode_evaluate_SD_fluctuation == 0:
         make_graph.dev_plot_av_with_mean_sd(angular_velocity_list, sd_list, mean_list, day)
     """
-    make_graph.dev_plot_sd_data_num(data_num_list, day)  # develop
+    make_graph.dev_plot_sd_data_num(data_num_list, day)
     for j, width in enumerate(width_time_list):
         data_num_mean_list = []
         for i in range(sample_num):

--- a/utils/functions/fluctuation_analysis.py
+++ b/utils/functions/fluctuation_analysis.py
@@ -54,9 +54,13 @@ def get_weighted_stats(
     if total_weight <= 0.0:
         return np.nan, np.nan
 
+    # Normalize weights: Σ w_i = 1
     normalized_weights = weights_arr / total_weight
+    # Weighted mean: μ = Σ (w_i * x_i) / Σ w_i
     weighted_mean = float(np.sum(normalized_weights * values_arr))
+    # Weighted variance: σ² = Σ (w_i * (x_i - μ)²) / Σ w_i
     weighted_variance = float(np.sum(normalized_weights * ((values_arr - weighted_mean) ** 2)))
+    # Weighted standard deviation: σ = sqrt(σ²)
     weighted_std = float(np.sqrt(weighted_variance))
 
     return weighted_std, weighted_mean

--- a/utils/functions/frequency_analysis.py
+++ b/utils/functions/frequency_analysis.py
@@ -55,7 +55,7 @@ def fft_angular_velocity(angular_velocity_list, day):
     save2csv.save_fft(save_dir, save_name, freq_list, Amp_list)
 
 
-def fft_sd_list(sd_list, day, flag_std):
+def fft_sd_list(df, day, flag_std=False):
     sample_num, FrameRate_list, _ = param.get_config(day)
     width_time_list = param.SD_window_width_list
     freq_list, Amp_list = [], []
@@ -63,7 +63,11 @@ def fft_sd_list(sd_list, day, flag_std):
     for i in range(sample_num):
         add_freq_list, add_Amp_list = [], []
         for j in range(len(width_time_list)):
-            freq, Amp = fft(sd_list[i][j], 1 / FrameRate_list[i])
+            if flag_std:
+                sd_list = df[f"No.{i + 1}_{width_time_list[j]}s_sd_std"].dropna().tolist()
+            else:
+                sd_list = df[f"No.{i + 1}_{width_time_list[j]}s_sd"].dropna().tolist()
+            freq, Amp = fft(sd_list, 1 / FrameRate_list[i])
             add_freq_list.append(freq.tolist())
             add_Amp_list.append(Amp.tolist())
         freq_list.append(add_freq_list)

--- a/utils/functions/make_graph.py
+++ b/utils/functions/make_graph.py
@@ -512,7 +512,7 @@ def plot_fft(freq_list, Amp_list, save_dir, save_name, day, flag_add_peak=False)
         rot_df_manage.update_rot_df(ROTATION_FEATURES.angle_FFT_peak, peak_list, day)
 
 
-def plot_SD_list(SD_list, day, flag_std):
+def plot_SD_list(df, day, flag_std=False):
     sample_num, _, _ = param.get_config(day)
     width_time_list = param.SD_window_width_list
     save_dir = f"{param.save_dir_bef}/{day}/fluctuation_analysis/SD-time-series/{param.get_SD_mode_label()}"
@@ -522,23 +522,26 @@ def plot_SD_list(SD_list, day, flag_std):
     rows = max(1, math.ceil(sample_num / cols))
     # sepalate save
     for i, width_time in enumerate(width_time_list):
-        time_list = read_csv.get_timelist(day)
-
         fig, axs = plt.subplots(rows, cols, figsize=(fig_size_x, fig_size_y))
         for j in range(sample_num):
             row = j // cols
             col = j % cols
-            axs[row, col].plot(time_list[j][: len(SD_list[j][i])], SD_list[j][i])
-            axs[row, col].grid(True)
+
+            time = df[f"No.{j + 1}_time"].dropna().tolist()
             if flag_std:
+                sd_list = df[f"No.{j + 1}_{width_time}s_sd_std"].tolist()
                 axs[row, col].set_title(f"Standardized SD Time-series No.{j+1}", fontsize=font_size)
                 axs[row, col].set_ylabel("Standardized SD", fontsize=font_size)
             else:
+                sd_list = df[f"No.{j + 1}_{width_time}s_sd"].tolist()
                 axs[row, col].set_title(f"SD Time-series No.{j+1}", fontsize=font_size)
                 axs[row, col].set_ylabel("SD", fontsize=font_size)
+
+            axs[row, col].plot(time, sd_list[: len(time)])
+            axs[row, col].grid(True)
             axs[row, col].set_xlabel("Time [s]", fontsize=font_size)
             axs[row, col].tick_params(axis="both", which="major", labelsize=font_size)
-            axs[row, col].set_xlim(0, time_list[j][len(SD_list[j][i])])
+            axs[row, col].set_xlim(0, time[-1])
         plt.tight_layout()
         if flag_std:
             plt.savefig(f"{save_dir}/SD-time-series_{width_time}s_standardized.png")
@@ -554,24 +557,25 @@ def plot_SD_list(SD_list, day, flag_std):
 
     fig, axs = plt.subplots(rows, cols, figsize=(fig_size_x, fig_size_y))
     for i, width_time in enumerate(width_time_list):
-        time_list = read_csv.get_timelist(day)
-
         for j in range(sample_num):
             row = j // cols
             col = j % cols
-            axs[row, col].plot(
-                time_list[j][: len(SD_list[j][i])], SD_list[j][i], label=f"SD {width_time}s", c=color_list[i], alpha=0.7
-            )
-            axs[row, col].grid(True)
+
+            time = df[f"No.{j + 1}_time"].dropna().tolist()
             if flag_std:
+                sd_list = df[f"No.{j + 1}_{width_time}s_sd_std"].tolist()
                 axs[row, col].set_title(f"Standardized SD Time-series No.{j+1}", fontsize=font_size)
                 axs[row, col].set_ylabel("Standardized SD", fontsize=font_size)
             else:
+                sd_list = df[f"No.{j + 1}_{width_time}s_sd"].tolist()
                 axs[row, col].set_title(f"SD time-series No.{j+1}", fontsize=font_size)
                 axs[row, col].set_ylabel("SD", fontsize=font_size)
+
+            axs[row, col].plot(time, sd_list[: len(time)], label=f"SD {width_time}s", c=color_list[i], alpha=0.7)
+            axs[row, col].grid(True)
             axs[row, col].set_xlabel("Time [s]", fontsize=font_size)
             axs[row, col].tick_params(axis="both", which="major", labelsize=font_size)
-            axs[row, col].set_xlim(0, time_list[j][len(SD_list[j][i])])
+            axs[row, col].set_xlim(0, time[-1])
     axs[-1][-1].legend(plot_label_list, loc="upper left", bbox_to_anchor=(1, 1))
     plt.tight_layout()
     if flag_std:
@@ -581,7 +585,7 @@ def plot_SD_list(SD_list, day, flag_std):
     plt.close(fig)
 
 
-def plot_sd_mean(sd_list, day):
+def plot_sd_mean(df, day):
     sample_num, _, _ = param.get_config(day)
     width_time_list = param.SD_window_width_list
     save_dir = f"{param.save_dir_bef}/{day}/fluctuation_analysis/SD-time-series/{param.get_SD_mode_label()}"
@@ -597,8 +601,8 @@ def plot_sd_mean(sd_list, day):
         axs = fig.add_subplot(gs[row, col])
 
         sd_mean_list = []
-        for j in range(len(width_time_list)):
-            sd_arr_i = np.asarray(sd_list[i][j])
+        for width_time in width_time_list:
+            sd_arr_i = np.asarray(df[f"No.{i + 1}_{width_time}s_sd"].dropna().tolist())
             sd_mean_list.append(np.mean(sd_arr_i))
 
         axs.plot(width_time_list, sd_mean_list, linewidth=4)
@@ -956,7 +960,7 @@ def dev_plot_av_with_stats(av_list, av_means, av_medians, day):
     plt.close(fig)
 
 
-def dev_plot_av_with_mean_sd(av_list, sd_list, mean_list, day):
+def dev_plot_av_with_mean_sd(av_list, df_sd, day):
     sample_num, _, _ = param.get_config(day)
     width_time_list = param.SD_window_width_list
     save_dir = f"{param.save_dir_bef}/{day}/fluctuation_analysis/SD-time-series/{param.get_SD_mode_label()}/av_with_sd"
@@ -965,30 +969,34 @@ def dev_plot_av_with_mean_sd(av_list, sd_list, mean_list, day):
     cols = 2
     rows = max(1, math.ceil(sample_num / cols))
     # sepalate save
-    for i, width_time in enumerate(width_time_list):
+    for width_time in width_time_list:
         time_list = read_csv.get_timelist(day)
 
         fig, axs = plt.subplots(rows, cols, figsize=(fig_size_x, fig_size_y))
-        for j in range(sample_num):
-            row = j // cols
-            col = j % cols
+        for i in range(sample_num):
+            row = i // cols
+            col = i % cols
 
-            time_arr = np.array(time_list[j])
-            av_arr = np.abs(np.array(av_list[j]))
-            sd_arr = np.array(sd_list[j][i])
-            mean_arr = np.array(mean_list[j][i])
+            # plot angular velocity
+            time_arr = np.array(time_list[i])
+            av_arr = np.abs(np.array(av_list[i]))
             axs[row, col].plot(time_arr[: len(av_arr)], av_arr, c="black", alpha=0.6)
+
+            # plot mean and sd
+            time_arr2 = df_sd[f"No.{i + 1}_time"]
+            sd_arr = df_sd[f"No.{i + 1}_{width_time}s_sd"]
+            mean_arr = df_sd[f"No.{i + 1}_{width_time}s_mean"]
             axs[row, col].fill_between(
-                time_arr[: len(sd_arr)],
+                time_arr2,
                 mean_arr - sd_arr,
                 mean_arr + sd_arr,
                 color="red",
                 alpha=0.4,
             )
-            axs[row, col].plot(time_arr[: len(mean_arr)], mean_arr, alpha=0.6)
+            axs[row, col].plot(time_arr2, mean_arr, alpha=0.6)
 
             axs[row, col].grid(True)
-            axs[row, col].set_title(f"SD Time-series No.{j+1}", fontsize=font_size)
+            axs[row, col].set_title(f"SD Time-series No.{i+1}", fontsize=font_size)
             axs[row, col].set_ylabel("SD", fontsize=font_size)
             axs[row, col].set_xlabel("Time [s]", fontsize=font_size)
             axs[row, col].tick_params(axis="both", which="major", labelsize=font_size)

--- a/utils/functions/save2csv.py
+++ b/utils/functions/save2csv.py
@@ -41,26 +41,6 @@ def save_angle_angular_velocity(angle_list, angular_velocity_list, day):
             csvwriter.writerow(row)
 
 
-def save_sd_time_series(sd_list, day, flag_std=False):
-    save_dir = f"{param.save_dir_bef}/{day}/fluctuation_analysis/SD-time-series"
-    os.makedirs(save_dir, exist_ok=True)
-    if flag_std:
-        csv_save_dir = f"{save_dir}/SD-time-series_std.csv"
-    else:
-        csv_save_dir = f"{save_dir}/SD-time-series.csv"
-
-    width_list = param.SD_window_width_list
-    data = {}
-    for i in range(len(sd_list)):
-        for j, width in enumerate(width_list):
-            key = f"No.{i+1}_{width}s"
-            data[key] = sd_list[i][j]
-
-    max_len = max(len(v) for v in data.values())
-    df = pd.DataFrame({k: v + [None] * (max_len - len(v)) for k, v in data.items()})
-    df.to_csv(csv_save_dir, index=False)
-
-
 def save_fft(save_dir, save_name, freq_list, Amp_list):
     csv_save_dir = f"{save_dir}/{save_name}.csv"
 

--- a/utils/param.py
+++ b/utils/param.py
@@ -145,6 +145,7 @@ flag_apply_gaussian_window = False
 
 # evaluate SD FFT low Amp and decline
 flag_evaluate_SD_FFT = True
+flag_use_std_df_to_FFT = True
 
 # compare fluctuation property
 flag_share_y_axis_across_width_time = False

--- a/utils/param.py
+++ b/utils/param.py
@@ -126,7 +126,7 @@ flag_eval_switching_with_averaged_av = False
 SD_window_width_list = [0.1, 0.2, 0.5, 1.0, 1.5, 2.0]
 
 # SD time-series fluctuation mode
-mode_evaluate_SD_fluctuation = 0
+mode_evaluate_SD_fluctuation = 1
 """
 0: SD
 1: SD / Mean
@@ -141,7 +141,8 @@ def get_SD_mode_label():
 
 
 # Obtain SD with gaussian window
-flag_apply_gaussian_window = False
+flag_apply_gaussian_window = True
+edge_peak_divisor = 10.0
 
 # evaluate SD FFT low Amp and decline
 flag_evaluate_SD_FFT = True

--- a/utils/param.py
+++ b/utils/param.py
@@ -126,7 +126,7 @@ flag_eval_switching_with_averaged_av = False
 SD_window_width_list = [0.1, 0.2, 0.5, 1.0, 1.5, 2.0]
 
 # SD time-series fluctuation mode
-mode_evaluate_SD_fluctuation = 1
+mode_evaluate_SD_fluctuation = 0
 """
 0: SD
 1: SD / Mean
@@ -139,6 +139,9 @@ def get_SD_mode_label():
     elif mode_evaluate_SD_fluctuation == 1:
         return "SD_per_mean"
 
+
+# Obtain SD with gaussian window
+flag_apply_gaussian_window = False
 
 # evaluate SD FFT low Amp and decline
 flag_evaluate_SD_FFT = True


### PR DESCRIPTION
時系列SD算出に使用する窓関数内でガウス関数を使用．
目的: SD算出時に窓中心をより強調させることで，時間分解能を向上させる．

- [x] 両端を1/nとするようにガウシアンを定義できるようにする．
- [x] 加重SDの算出式を明示する
- [] READMEの更新
