### PR TITLE
Feature/repellent response analysis

### DIFF
--- a/scripts/04_repellent_response_analysis.py
+++ b/scripts/04_repellent_response_analysis.py
@@ -44,7 +44,8 @@ def main(
     if not os.path.isfile(centroid_csv):
         if os.path.isfile(base_centroid_csv):
             os.makedirs(os.path.dirname(centroid_csv), exist_ok=True)
-            subprocess.run(["cp", base_centroid_csv, centroid_csv], check=True)
+            import shutil
+            shutil.copy2(base_centroid_csv, centroid_csv)
         else:
             try:
                 script_path = os.path.join(

--- a/scripts/04_repellent_response_analysis.py
+++ b/scripts/04_repellent_response_analysis.py
@@ -25,9 +25,6 @@ def main(
     os.makedirs(f"{repellent_root}/02_pre_rise_fluctuation", exist_ok=True)
     os.makedirs(f"{repellent_root}/03_post_rise_analysis/centroid_coordinate", exist_ok=True)
 
-    # Default repellent dataset may not have config.ini; create a minimal one when missing.
-    repellent_response.ensure_repellent_config(day)
-
     # Keep time-list generation aligned with existing implementation.
     time_list = repellent_response.ensure_time_list(day)
     save2csv.save_repellent_time_list(time_list, day)
@@ -65,7 +62,7 @@ def main(
     make_graph.plot_repellent_background_intensity(time_list, background_list, rise_indices, day)
 
     # Build all-time centroid components once, then split into pre/post later.
-    post_rise_center_mode = repellent_response.get_post_rise_center_mode(day)
+    post_rise_center_mode = param.get_post_rise_center_mode(day)
     all_comp_time_list, all_x_before_list, all_y_before_list = repellent_response.build_all_time_raw_centroid_series(
         day=day,
         time_list=time_list,

--- a/scripts/04_repellent_response_analysis.py
+++ b/scripts/04_repellent_response_analysis.py
@@ -62,7 +62,7 @@ def main(
     make_graph.plot_repellent_background_intensity(time_list, background_list, rise_indices, day)
 
     # Build all-time centroid components once, then split into pre/post later.
-    post_rise_center_mode = param.get_post_rise_center_mode(day)
+    post_rise_center_mode = param.post_rise_center_mode
     all_comp_time_list, all_x_before_list, all_y_before_list = repellent_response.build_all_time_raw_centroid_series(
         day=day,
         time_list=time_list,

--- a/scripts/04_repellent_response_analysis.py
+++ b/scripts/04_repellent_response_analysis.py
@@ -353,12 +353,9 @@ def main(
         window_width_sec=param.av_switching_window_width_sec,
         window_shift_sec=param.av_switching_window_shift_sec,
     )
-    save2csv.save_angular_velocity_switching_frequency(
-        switching_time_list, switching_freq_list, day
-    )
+    save2csv.save_angular_velocity_switching_frequency(switching_time_list, switching_freq_list, day)
     make_graph.plot_angular_velocity_switching_frequency(
-        switching_time_list, switching_freq_list, day,
-        sample_indices=[idx + 1 for idx in all_rot["valid_indices"]]
+        switching_time_list, switching_freq_list, day, sample_indices=[idx + 1 for idx in all_rot["valid_indices"]]
     )
 
 

--- a/scripts/04_repellent_response_analysis.py
+++ b/scripts/04_repellent_response_analysis.py
@@ -57,7 +57,7 @@ def main(
         sigma_threshold=sigma_threshold,
         min_consecutive=min_consecutive,
     )
-    repellent_response.add_rise_time_to_results(rise_results, time_list)
+    repellent_response.add_rise_time_to_results(day, rise_results, time_list)
     rise_indices = [result["rise_index"] for result in rise_results]
 
     save2csv.save_repellent_background_intensity(time_list, background_list, day)
@@ -137,6 +137,7 @@ def main(
             bg_for_av.append(background_list[idx])
         else:
             bg_for_av.append([])
+
     make_graph.plot_repellent_background_and_av_stacked(
         time_list=all_rot["time_list"],
         background_list=bg_for_av,
@@ -145,6 +146,38 @@ def main(
         sample_indices=[idx + 1 for idx in all_rot["valid_indices"]],
         rise_time_list=all_rise_time_for_av,
     )
+
+    switching_time_list, switching_count_list = repellent_response.calculate_angular_velocity_switching_count(
+        time_list=all_rot["time_list"],
+        angular_velocity_list=all_rot["angular_velocity_list"],
+        window_width_sec=1.0,
+    )
+    save2csv.save_angular_velocity_switching_count(
+        switching_time_list,
+        switching_count_list,
+        day,
+    )
+    make_graph.plot_angular_velocity_switching_count(
+        switching_time_list,
+        switching_count_list,
+        day,
+        sample_indices=[idx + 1 for idx in all_rot["valid_indices"]],
+        rise_time_list=all_rise_time_for_av,
+    )
+
+    legacy_switching_csv = (
+        f"{param.save_dir_bef}/{day}/repellent_response/03_post_rise_analysis/"
+        "angular_velocity/switching_frequency.csv"
+    )
+    legacy_switching_png = (
+        f"{param.save_dir_bef}/{day}/repellent_response/03_post_rise_analysis/"
+        "angular_velocity/switching_frequency.png"
+    )
+    if os.path.isfile(legacy_switching_csv):
+        os.remove(legacy_switching_csv)
+    if os.path.isfile(legacy_switching_png):
+        os.remove(legacy_switching_png)
+
     all_rise_time_for_centroid = [result.get("rise_time", float("nan")) for result in rise_results]
     make_graph.plot_repellent_component_panels(
         all_comp_time_list,
@@ -344,18 +377,6 @@ def main(
         day,
         "Centroid Corrected",
         "centroid_corrected.png",
-    )
-
-    # Calculate and plot angular velocity switching frequency
-    switching_time_list, switching_freq_list = repellent_response.calculate_angular_velocity_switching_frequency(
-        time_list=post_av_time_list,
-        angular_velocity_list=post_av_list,
-        window_width_sec=param.av_switching_window_width_sec,
-        window_shift_sec=param.av_switching_window_shift_sec,
-    )
-    save2csv.save_angular_velocity_switching_frequency(switching_time_list, switching_freq_list, day)
-    make_graph.plot_angular_velocity_switching_frequency(
-        switching_time_list, switching_freq_list, day, sample_indices=[idx + 1 for idx in all_rot["valid_indices"]]
     )
 
 

--- a/scripts/04_repellent_response_analysis.py
+++ b/scripts/04_repellent_response_analysis.py
@@ -346,6 +346,21 @@ def main(
         "centroid_corrected.png",
     )
 
+    # Calculate and plot angular velocity switching frequency
+    switching_time_list, switching_freq_list = repellent_response.calculate_angular_velocity_switching_frequency(
+        time_list=post_av_time_list,
+        angular_velocity_list=post_av_list,
+        window_width_sec=param.av_switching_window_width_sec,
+        window_shift_sec=param.av_switching_window_shift_sec,
+    )
+    save2csv.save_angular_velocity_switching_frequency(
+        switching_time_list, switching_freq_list, day
+    )
+    make_graph.plot_angular_velocity_switching_frequency(
+        switching_time_list, switching_freq_list, day,
+        sample_indices=[idx + 1 for idx in all_rot["valid_indices"]]
+    )
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/scripts/04_repellent_response_analysis.py
+++ b/scripts/04_repellent_response_analysis.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import subprocess
 import sys
+from typing import Optional
 
 os.environ.setdefault("MPLBACKEND", "Agg")
 os.environ.setdefault("MPLCONFIGDIR", "/tmp/matplotlib")
@@ -16,7 +17,14 @@ def main(
     baseline_ratio: float,
     sigma_threshold: float,
     min_consecutive: int,
+    post_rise_center_mode: int,
+    output_suffix: Optional[str],
 ):
+    base_save_dir = param.save_dir_bef
+    if output_suffix is not None and output_suffix != "":
+        param.save_dir_bef = f"{base_save_dir}/{output_suffix}"
+    param.post_rise_center_mode = post_rise_center_mode
+
     repellent_root = f"{param.save_dir_bef}/{day}/repellent_response"
     repellent_response.cleanup_legacy_repellent_outputs(day)
     os.makedirs(f"{repellent_root}/00_all_rotational_analysis", exist_ok=True)
@@ -32,17 +40,22 @@ def main(
 
     # Reuse existing centroid / angular-velocity pipeline.
     centroid_csv = f"{param.save_dir_bef}/{day}/centroid_coordinate.csv"
+    base_centroid_csv = f"{base_save_dir}/{day}/centroid_coordinate.csv"
     if not os.path.isfile(centroid_csv):
-        try:
-            script_path = os.path.join(
-                os.path.dirname(os.path.dirname(__file__)),
-                "utils",
-                "functions",
-                "get_centroid_coordinate.py",
-            )
-            subprocess.run([sys.executable, script_path, day], check=True)
-        except subprocess.CalledProcessError:
-            repellent_response.generate_centroid_coordinate_simple(day)
+        if os.path.isfile(base_centroid_csv):
+            os.makedirs(os.path.dirname(centroid_csv), exist_ok=True)
+            subprocess.run(["cp", base_centroid_csv, centroid_csv], check=True)
+        else:
+            try:
+                script_path = os.path.join(
+                    os.path.dirname(os.path.dirname(__file__)),
+                    "utils",
+                    "functions",
+                    "get_centroid_coordinate.py",
+                )
+                subprocess.run([sys.executable, script_path, day], check=True)
+            except subprocess.CalledProcessError:
+                repellent_response.generate_centroid_coordinate_simple(day)
     x_list, y_list = input_data.input_centroid_coordinate(day)
     x_list, y_list = repellent_response.align_coordinate_series_to_time(x_list, y_list, time_list)
 
@@ -62,7 +75,6 @@ def main(
     make_graph.plot_repellent_background_intensity(time_list, background_list, rise_indices, day)
 
     # Build all-time centroid components once, then split into pre/post later.
-    post_rise_center_mode = param.post_rise_center_mode
     all_comp_time_list, all_x_before_list, all_y_before_list = repellent_response.build_all_time_raw_centroid_series(
         day=day,
         time_list=time_list,
@@ -384,6 +396,8 @@ if __name__ == "__main__":
     parser.add_argument("--baseline-ratio", type=float, default=0.5)
     parser.add_argument("--sigma-threshold", type=float, default=3.0)
     parser.add_argument("--min-consecutive", type=int, default=3)
+    parser.add_argument("--post-rise-center-mode", type=int, choices=[1, 2, 3], default=param.post_rise_center_mode)
+    parser.add_argument("--output-suffix", type=str, default=None)
 
     args = parser.parse_args()
 
@@ -392,4 +406,6 @@ if __name__ == "__main__":
         baseline_ratio=args.baseline_ratio,
         sigma_threshold=args.sigma_threshold,
         min_consecutive=args.min_consecutive,
+        post_rise_center_mode=args.post_rise_center_mode,
+        output_suffix=args.output_suffix,
     )

--- a/scripts/04_repellent_response_analysis.py
+++ b/scripts/04_repellent_response_analysis.py
@@ -45,6 +45,7 @@ def main(
         if os.path.isfile(base_centroid_csv):
             os.makedirs(os.path.dirname(centroid_csv), exist_ok=True)
             import shutil
+
             shutil.copy2(base_centroid_csv, centroid_csv)
         else:
             try:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -45,6 +45,41 @@ python3 scripts/01_standard_analyisis/rotation_analysis_main.py --day [directory
 python3 scripts/01_standard_analyisis/rotation_analysis_main.py --day [directory_name_to_analyze] --fluc
 ```
 
+### 2.4. Repellent Response Analysis
+
+Repellent response analysis can be performed by executing the following command:
+
+```bash
+python3 scripts/04_repellent_response_analysis.py --day [day_directory]
+```
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `--day` | str | `repellent-response/20260312` | Data directory (subdirectory in `data/`) |
+| `--baseline-ratio` | float | `0.5` | Baseline ratio for rise-point detection |
+| `--sigma-threshold` | float | `3.0` | Standard deviation threshold for rise-point detection |
+| `--min-consecutive` | int | `3` | Minimum consecutive frames for rise detection |
+
+**Example:**
+
+```bash
+python3 scripts/04_repellent_response_analysis.py --day repellent-response/20260416_23
+python3 scripts/04_repellent_response_analysis.py --day repellent-response/20260416_23 \
+  --baseline-ratio 0.4 --sigma-threshold 2.5 --min-consecutive 4
+```
+
+**Output directory structure:**
+
+Generated outputs are saved in `outputs/{day}/repellent_response/`:
+
+- `00_time_list/`: Time list and visualization  
+- `01_brightness_change/`: Background intensity and rise detection results  
+- `00_all_rotational_analysis/`: All-time rotational analysis, including centroid coordinates, rotation center, and angular velocity  
+- `02_pre_rise_fluctuation/`: Pre-rise rotational and fluctuation analyses  
+- `03_post_rise_analysis/`: Post-rise centroid and angular velocity analysis
+
 ## 日本語版
 
 # スクリプトディレクトリ
@@ -92,3 +127,38 @@ python3 scripts/01_standard_analyisis/rotation_analysis_main.py --day [directory
 ```bash
 python3 scripts/01_standard_analyisis/rotation_analysis_main.py --day [directory_name_to_analyze] --fluc
 ```
+
+### 2.4. 忌避応答解析
+
+忌避応答解析は以下のコマンドで実行できます。
+
+```bash
+python3 scripts/04_repellent_response_analysis.py --day [day_directory]
+```
+
+**パラメータ：**
+
+| パラメータ | 型 | デフォルト値 | 説明 |
+|-----------|-----|--------|------|
+| `--day` | str | `repellent-response/20260312` | データディレクトリ（`data/` 配下のサブディレクトリ） |
+| `--baseline-ratio` | float | `0.5` | ベースライン比率（rise point検出用） |
+| `--sigma-threshold` | float | `3.0` | 標準偏差の閾値（rise point検出用） |
+| `--min-consecutive` | int | `3` | rise検出の最小連続フレーム数 |
+
+**実行例：**
+
+```bash
+python3 scripts/04_repellent_response_analysis.py --day repellent-response/20260416_23
+python3 scripts/04_repellent_response_analysis.py --day repellent-response/20260416_23 \
+  --baseline-ratio 0.4 --sigma-threshold 2.5 --min-consecutive 4
+```
+
+**出力ディレクトリ構成：**
+
+生成された出力は `outputs/{day}/repellent_response/` に保存されます。
+
+- `00_time_list/`: 時刻リストと可視化  
+- `01_brightness_change/`: 背景輝度と rise検出結果  
+- `00_all_rotational_analysis/`: 全時間の回転解析（重心座標、回転中心、角速度を含む）  
+- `02_pre_rise_fluctuation/`: pre-rise の回転解析と揺らぎ解析  
+- `03_post_rise_analysis/`: post-rise の重心座標と角速度解析

--- a/utils/functions/clean_data.py
+++ b/utils/functions/clean_data.py
@@ -92,8 +92,6 @@ def correct_rotation_center(data, idx, day, xy_label):
             if neighbors:
                 data_aft.append(np.nanmean(neighbors))
             else:
-                # Warning if all neighbors are in complement_index_list
-                print(f"Warning: All neighbors of index {j} (in No.{idx+1} {xy_label}) are in complement_index_list.")
                 valid_data = [x for index, x in enumerate(data) if index not in complement_index_list]
                 if valid_data:
                     data_aft.append(np.nanmean(valid_data))

--- a/utils/functions/frequency_analysis.py
+++ b/utils/functions/frequency_analysis.py
@@ -5,7 +5,12 @@ from utils.functions import get_angular_velocity, make_graph, save2csv
 
 
 def fft(data_bef, dt):
-    data_aft = np.array(data_bef) - np.average(np.array(data_bef))
+    data_arr = np.asarray(data_bef, dtype=float)
+    if data_arr.size == 0 or not np.isfinite(data_arr).any():
+        empty = np.asarray([], dtype=float)
+        return empty, empty
+
+    data_aft = data_arr - np.nanmean(data_arr)
     N = len(data_aft)
     # FFT
     F = np.fft.fft(data_aft)

--- a/utils/functions/get_angular_velocity.py
+++ b/utils/functions/get_angular_velocity.py
@@ -131,7 +131,10 @@ def get_angular_velocity(x_list, y_list, day):
             if flag_use_conts_width_time:
                 width_time = conts_width_time
             else:
-                width_time = param.n_rotations / freq_list[i][np.argmax(Amp_list[i])]
+                if len(freq_list[i]) == 0 or len(Amp_list[i]) == 0 or not np.isfinite(Amp_list[i]).any():
+                    width_time = conts_width_time
+                else:
+                    width_time = param.n_rotations / freq_list[i][int(np.nanargmax(Amp_list[i]))]
 
             add_angular_velocity_mean = []
             start_time = 0.0

--- a/utils/functions/get_centroid_coordinate.py
+++ b/utils/functions/get_centroid_coordinate.py
@@ -139,9 +139,17 @@ def calculate_ellipse_properties(X, Y):
     X = np.asarray(X, dtype=np.float64)
     Y = np.asarray(Y, dtype=np.float64)
 
+    if X.size < 5 or Y.size < 5:
+        return np.nan, np.nan, np.nan, np.nan, True
+    if not np.isfinite(X).any() or not np.isfinite(Y).any():
+        return np.nan, np.nan, np.nan, np.nan, True
+
     A = np.hstack([X**2, X * Y, Y**2, X, Y])
     b = np.ones_like(X)
-    x_arr = np.linalg.lstsq(A, b, rcond=None)[0].squeeze()
+    try:
+        x_arr = np.linalg.lstsq(A, b, rcond=None)[0].squeeze()
+    except np.linalg.LinAlgError:
+        return np.nan, np.nan, np.nan, np.nan, True
     x = x_arr.tolist()
     flag_Warning = False
 

--- a/utils/functions/get_centroid_coordinate.py
+++ b/utils/functions/get_centroid_coordinate.py
@@ -211,7 +211,17 @@ def get_ellipse_info(X, Y, index, day):
         x_freq_list, x_Amp_list = x_freq_list[x_mask], x_Amp_list[x_mask]
         y_freq_list, y_Amp_list = y_freq_list[y_mask], y_Amp_list[y_mask]
 
-        width_time = param.n_rotations / max(x_freq_list[np.argmax(x_Amp_list)], y_freq_list[np.argmax(y_Amp_list)])
+        peak_candidates = []
+        if x_freq_list.size > 0 and x_Amp_list.size > 0 and np.isfinite(x_Amp_list).any():
+            peak_candidates.append(float(x_freq_list[int(np.nanargmax(x_Amp_list))]))
+        if y_freq_list.size > 0 and y_Amp_list.size > 0 and np.isfinite(y_Amp_list).any():
+            peak_candidates.append(float(y_freq_list[int(np.nanargmax(y_Amp_list))]))
+        if peak_candidates:
+            peak_freq = max(peak_candidates)
+        else:
+            peak_freq = 0.1
+
+        width_time = param.n_rotations / max(peak_freq, 1e-6)
         print(f"No.{index + 1}   width_time: {width_time:.2f} s")
 
         start_time = 0.0

--- a/utils/functions/get_centroid_coordinate.py
+++ b/utils/functions/get_centroid_coordinate.py
@@ -28,6 +28,8 @@ def contours(img):
     img_gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
     _, img_binary = cv2.threshold(img_gray, 120, 255, cv2.THRESH_BINARY)
     contours, _ = cv2.findContours(img_binary, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    if len(contours) == 0:
+        return np.nan, np.nan, None
     max_contour = max(contours, key=cv2.contourArea)
 
     # Centroid coordinates were taken as the mean of the contours.
@@ -37,7 +39,7 @@ def contours(img):
         ellipse = cv2.fitEllipse(max_contour)
         return mean_x, mean_y, ellipse
     else:
-        return None, None, None
+        return np.nan, np.nan, None
 
 
 # Save centroid coordinates (cannot be written in save2csv.py due to subprocess)
@@ -430,7 +432,7 @@ def main(day):
                 break
             if param.flag_get_angle_with_cell_direcetion:
                 x, y, ellipse = contours(frame)
-                add_angle_list_bef.append(ellipse[2])
+                add_angle_list_bef.append(ellipse[2] if ellipse is not None else np.nan)
             else:
                 x, y, _ = contours(frame)
             add_x_list.append(x * px2um_x)

--- a/utils/functions/make_graph.py
+++ b/utils/functions/make_graph.py
@@ -1,5 +1,6 @@
 import math
 import os
+from typing import Optional, Sequence
 
 import matplotlib.gridspec as gridspec
 import matplotlib.pyplot as plt
@@ -68,6 +69,7 @@ def plot_coordinate(x_list, y_list, day, mode):
     rows = max(1, math.ceil(sample_num / cols))
     for label_i, xy_list in enumerate([x_list, y_list]):
         fig, axs = plt.subplots(rows, cols, figsize=(20, 4 * rows))
+        axs = np.atleast_2d(axs)
         for i in range(sample_num):
             row = i // cols
             col = i % cols
@@ -129,6 +131,7 @@ def plot_coordinate_with_center(x_list, y_list, center_x_list, center_y_list, da
     rows = max(1, math.ceil(sample_num / cols))
     for axis_label in ["x", "y"]:
         fig, axs = plt.subplots(rows, cols, figsize=(20, 4 * rows))
+        axs = np.atleast_2d(axs)
         plot_label = ["centroid", "center"]
         if axis_label == "x":
             xy_list = x_list
@@ -203,6 +206,7 @@ def plot_rot_axes(long_axis_arr, short_axis_arr, aspect_ratio_arr, day):
     cols = 2
     rows = max(1, math.ceil(sample_num / cols))
     fig, axs = plt.subplots(rows, 2 * cols, figsize=(2 * fig_size_x, fig_size_y))
+    axs = np.atleast_2d(axs)
     for i in range(sample_num):
         row = i // cols
         col = i % cols
@@ -237,6 +241,7 @@ def plot_r(r_arr, day):
     cols = 2
     rows = max(1, math.ceil(sample_num / cols))
     fig, axs = plt.subplots(rows, cols, figsize=(fig_size_x, 23 * rows / 5))
+    axs = np.atleast_2d(axs)
     for i in range(sample_num):
         row = i // cols
         col = i % cols
@@ -260,6 +265,7 @@ def plot_angular_velocity(angle_list, angular_velocity_list, day):
     cols = 2
     rows = max(1, math.ceil(sample_num / cols))
     fig, axs = plt.subplots(rows, cols, figsize=(fig_size_x, fig_size_y * rows / 5))
+    axs = np.atleast_2d(axs)
     axs = np.atleast_2d(axs)
     for i in range(sample_num):
         row = i // cols
@@ -428,6 +434,7 @@ def plot_angular_velocity_rot_part(angular_velocity_list, th_list, th_list_means
     rows = max(1, math.ceil(sample_num / cols))
 
     fig, axs = plt.subplots(rows, cols, figsize=(fig_size_x, fig_size_y * rows / 5))
+    axs = np.atleast_2d(axs)
     for i in range(sample_num):
         row = i // cols
         col = i % cols
@@ -459,6 +466,7 @@ def plot_averaged_angular_velocity(angular_velocity_list, angular_velocity_mean_
     cols = 2
     rows = max(1, math.ceil(sample_num / cols))
     fig, axs = plt.subplots(rows, cols, figsize=(fig_size_x, fig_size_y * rows / 5))
+    axs = np.atleast_2d(axs)
     plot_label = ["original", "mean"]
     for i in range(sample_num):
         row = i // cols
@@ -542,6 +550,7 @@ def plot_SD_list(df, day, flag_std=False):
     # sepalate save
     for i, width_time in enumerate(width_time_list):
         fig, axs = plt.subplots(rows, cols, figsize=(fig_size_x, fig_size_y * rows / 5))
+        axs = np.atleast_2d(axs)
         for j in range(sample_num):
             row = j // cols
             col = j % cols
@@ -575,6 +584,7 @@ def plot_SD_list(df, day, flag_std=False):
         plot_label_list.append(f"SD {width_time}s")
 
     fig, axs = plt.subplots(rows, cols, figsize=(fig_size_x, fig_size_y * rows / 5))
+    axs = np.atleast_2d(axs)
     for i, width_time in enumerate(width_time_list):
         for j in range(sample_num):
             row = j // cols
@@ -651,6 +661,7 @@ def plot_SD_list_fft(freq_list, Amp_list, day, flag_std):
     # sepalate save
     for i, width_time in enumerate(width_time_list):
         fig, axs = plt.subplots(rows, cols, figsize=(fig_size_x, fig_size_y * rows / 5))
+        axs = np.atleast_2d(axs)
         for j in range(sample_num):
             row = j // cols
             col = j % cols
@@ -680,6 +691,7 @@ def plot_SD_list_fft(freq_list, Amp_list, day, flag_std):
         plot_label_list.append(f"SD {width_time}s")
 
     fig, axs = plt.subplots(rows, cols, figsize=(fig_size_x, fig_size_y * rows / 5))
+    axs = np.atleast_2d(axs)
     for i, width_time in enumerate(width_time_list):
         for j in range(sample_num):
             row = j // cols
@@ -792,11 +804,11 @@ def plot_rot_param(day):
             if flag_i_width_depend:
                 data_i_aft = data_i_bef.copy()
             else:
-                data_i_aft = [data_i_bef[0] for _ in range(sample_num)]
+                data_i_aft = [data_i_bef[0] for _ in range(len(width_time_list))]
             if flag_j_width_depend:
                 data_j_aft = data_j_bef.copy()
             else:
-                data_j_aft = [data_j_bef[0] for _ in range(sample_num)]
+                data_j_aft = [data_j_bef[0] for _ in range(len(width_time_list))]
 
             # plot
             if flag_i_width_depend or flag_j_width_depend:
@@ -830,6 +842,7 @@ def dev_plot_centroid_and_center(x_list, y_list, center_x_list, center_y_list, d
     for flag_normalize in [False, True]:
         for label in ["x", "y"]:
             fig, axs = plt.subplots(rows, cols, figsize=(fig_size_x, fig_size_y))
+            axs = np.atleast_2d(axs)
             plot_label = ["centroid", "center"]
             if label == "x":
                 xy_list = x_list
@@ -892,6 +905,7 @@ def dev_plot_time_list(day):
     cols = 2
     rows = max(1, math.ceil(sample_num / cols))
     fig, axs = plt.subplots(rows, 2 * cols, figsize=(2 * fig_size_x, fig_size_y))
+    axs = np.atleast_2d(axs)
     for i in range(sample_num):
         row = i // cols
         col = i % cols
@@ -929,6 +943,7 @@ def dev_plot_sd_data_num(data_num_list, day):
     cols = 2
     rows = max(1, math.ceil(sample_num / cols))
     fig, axs = plt.subplots(rows, cols, figsize=(fig_size_x, fig_size_y))
+    axs = np.atleast_2d(axs)
     for i, width_time in enumerate(width_time_list):
         time_list = read_csv.get_timelist(day)
 
@@ -964,6 +979,7 @@ def dev_plot_av_with_stats(av_list, av_means, av_medians, day):
     rows = max(1, math.ceil(sample_num / cols))
 
     fig, axs = plt.subplots(rows, cols, figsize=(fig_size_x, fig_size_y))
+    axs = np.atleast_2d(axs)
     for i in range(sample_num):
         row = i // cols
         col = i % cols
@@ -994,6 +1010,7 @@ def dev_plot_av_with_mean_sd(av_list, df_sd, day):
         time_list = read_csv.get_timelist(day)
 
         fig, axs = plt.subplots(rows, cols, figsize=(fig_size_x, fig_size_y))
+        axs = np.atleast_2d(axs)
         for i in range(sample_num):
             row = i // cols
             col = i % cols
@@ -1048,7 +1065,9 @@ def dev_plot_sd_FFT_with_rotation(freq_list, Amp_list, day):
     cols = 2
     rows = max(1, math.ceil(sample_num / cols))
     fig, axs = plt.subplots(rows, cols, figsize=(fig_size_x, fig_size_y + 2))
+    axs = np.atleast_2d(axs)
     # fig, axs = plt.subplots(5, sample_num // 5, figsize=(15, 23))
+    axs = np.atleast_2d(axs)
     # Angular Velocisy
     for j in range(sample_num):
         row = j // cols
@@ -1085,6 +1104,7 @@ def dev_plot_fft_coordinates(X, Y, day):
     rows = max(1, math.ceil(sample_num / cols))
 
     fig, axs = plt.subplots(rows, 2 * cols, figsize=(2 * fig_size_x, fig_size_y))
+    axs = np.atleast_2d(axs)
     for i in range(sample_num):
         x_freq_list, x_Amp_list = frequency_analysis.fft(X[i], 1 / FrameRate[i])
         y_freq_list, y_Amp_list = frequency_analysis.fft(Y[i], 1 / FrameRate[i])
@@ -1123,6 +1143,7 @@ def dev_plot_max_dist_stat(max_dists, max_dists_all, day):
     cols = 2
     rows = max(1, math.ceil(sample_num / cols))
     fig, axs = plt.subplots(rows, cols, figsize=(50 * mag / 4, 20 * mag / 4))
+    axs = np.atleast_2d(axs)
     axs = axs.flatten()
     for i, data in enumerate(max_dists):
         axs[i].boxplot(data * 1000, positions=[1])
@@ -1461,6 +1482,7 @@ def plot_repellent_component_panels(
     rows = max(1, sample_num)
     cols = 3  # x-y, x-t, y-t
     fig, axs = plt.subplots(rows, cols, figsize=(3 * fig_size_x / 2, max(6, rows * 4)))
+    axs = np.atleast_2d(axs)
     if rows == 1:
         axs = np.array([axs])
 

--- a/utils/functions/make_graph.py
+++ b/utils/functions/make_graph.py
@@ -1674,36 +1674,60 @@ def plot_repellent_angular_velocity_onecol(time_list, angle_list, angular_veloci
     )
 
 
-def plot_angular_velocity_switching_frequency(
-    time_list: Sequence[Sequence[float]],
-    frequency_list: Sequence[Sequence[float]],
-    day: str,
-    sample_indices: Optional[Sequence[int]] = None,
-) -> None:
-    """Plot switching frequency time-series."""
-    if not time_list or not frequency_list:
-        return
-
+def plot_angular_velocity_switching_count(
+    time_list,
+    count_list,
+    day,
+    sample_indices=None,
+    rise_time_list=None,
+):
+    sample_num = len(time_list)
     if sample_indices is None:
-        sample_indices = list(range(1, len(time_list) + 1))
+        sample_indices = [i + 1 for i in range(sample_num)]
 
-    fig, ax = plt.subplots(figsize=(12, 6))
-
-    for idx, (t_series, f_series) in enumerate(zip(time_list, frequency_list)):
-        if len(t_series) > 0 and len(f_series) > 0:
-            sample_no = sample_indices[idx] if idx < len(sample_indices) else idx + 1
-            ax.plot(t_series, f_series, marker="o", markersize=4, label=f"No.{sample_no}", linewidth=2)
-
-    ax.set_xlabel("Time (s)", fontsize=12)
-    ax.set_ylabel("Sign Reversal Frequency (1/s)", fontsize=12)
-    ax.set_title("Angular Velocity Sign-Reversal Frequency (Post-rise)", fontsize=14, fontweight="bold")
-    ax.legend(loc="best", fontsize=10)
-    ax.grid(True, alpha=0.3)
-
-    save_dir = f"{param.save_dir_bef}/{day}/repellent_response/03_post_rise_analysis/angular_velocity"
+    save_dir = f"{param.save_dir_bef}/{day}/repellent_response/00_all_rotational_analysis/angular_velocity"
     os.makedirs(save_dir, exist_ok=True)
 
-    save_path = f"{save_dir}/switching_frequency.png"
-    fig.tight_layout()
-    fig.savefig(save_path, dpi=100)
+    cols = 2
+    rows = max(1, math.ceil(sample_num / cols))
+    fig, axs = plt.subplots(rows, cols, figsize=(fig_size_x, fig_size_y * rows / 5))
+    axs = np.atleast_2d(axs)
+
+    for i in range(rows * cols):
+        row = i // cols
+        col = i % cols
+
+        if i >= sample_num:
+            axs[row, col].axis("off")
+            continue
+
+        t = np.asarray(time_list[i], dtype=float)
+        c = np.asarray(count_list[i], dtype=float)
+        n = min(len(t), len(c))
+
+        if n == 0:
+            axs[row, col].axis("off")
+            continue
+
+        t = t[:n]
+        c = c[:n]
+
+        axs[row, col].plot(t, c)
+        axs[row, col].grid(True)
+        axs[row, col].set_title(f"Switching Count Time-series No.{sample_indices[i]}", fontsize=font_size)
+        axs[row, col].set_xlabel("Time [s]", fontsize=font_size)
+        axs[row, col].set_ylabel("Switching Count [/1 s window]", fontsize=font_size)
+        axs[row, col].tick_params(axis="both", which="major", labelsize=font_size)
+
+        finite_t = t[np.isfinite(t)]
+        if finite_t.size > 0:
+            axs[row, col].set_xlim(0, finite_t[-1])
+
+        if rise_time_list is not None and i < len(rise_time_list):
+            rise_time = rise_time_list[i]
+            if rise_time is not None and np.isfinite(rise_time):
+                axs[row, col].axvline(rise_time, color="red", linestyle="--")
+
+    plt.tight_layout()
+    plt.savefig(f"{save_dir}/switching_count.png")
     plt.close(fig)

--- a/utils/functions/make_graph.py
+++ b/utils/functions/make_graph.py
@@ -260,6 +260,7 @@ def plot_angular_velocity(angle_list, angular_velocity_list, day):
     cols = 2
     rows = max(1, math.ceil(sample_num / cols))
     fig, axs = plt.subplots(rows, cols, figsize=(fig_size_x, fig_size_y * rows / 5))
+    axs = np.atleast_2d(axs)
     for i in range(sample_num):
         row = i // cols
         col = i % cols
@@ -275,6 +276,7 @@ def plot_angular_velocity(angle_list, angular_velocity_list, day):
     plt.close(fig)
 
     fig, axs = plt.subplots(rows, cols, figsize=(fig_size_x, fig_size_y * rows / 5))
+    axs = np.atleast_2d(axs)
     for i in range(sample_num):
         row = i // cols
         col = i % cols
@@ -290,6 +292,7 @@ def plot_angular_velocity(angle_list, angular_velocity_list, day):
     plt.close(fig)
 
     fig, axs = plt.subplots(rows, cols, figsize=(fig_size_x, fig_size_y * rows / 5))
+    axs = np.atleast_2d(axs)
     for i in range(sample_num):
         row = i // cols
         col = i % cols
@@ -487,6 +490,7 @@ def plot_fft(freq_list, Amp_list, save_dir, save_name, day, flag_add_peak=False)
     cols = 2
     rows = max(1, math.ceil(sample_num / cols))
     fig, axs = plt.subplots(rows, cols, figsize=(fig_size_x, fig_size_y * rows / 5))
+    axs = np.atleast_2d(axs)
     for i in range(sample_num):
         row = i // cols
         col = i % cols

--- a/utils/functions/make_graph.py
+++ b/utils/functions/make_graph.py
@@ -1072,7 +1072,6 @@ def dev_plot_sd_FFT_with_rotation(freq_list, Amp_list, day):
     fig, axs = plt.subplots(rows, cols, figsize=(fig_size_x, fig_size_y + 2))
     axs = np.atleast_2d(axs)
     # fig, axs = plt.subplots(5, sample_num // 5, figsize=(15, 23))
-    axs = np.atleast_2d(axs)
     # Angular Velocisy
     for j in range(sample_num):
         row = j // cols

--- a/utils/functions/make_graph.py
+++ b/utils/functions/make_graph.py
@@ -1650,3 +1650,40 @@ def plot_repellent_angular_velocity_onecol(time_list, angle_list, angular_veloci
         "Angular Velocity Abs Time-series",
         use_abs=True,
     )
+
+
+def plot_angular_velocity_switching_frequency(
+    time_list: Sequence[Sequence[float]],
+    frequency_list: Sequence[Sequence[float]],
+    day: str,
+    sample_indices: Optional[Sequence[int]] = None,
+) -> None:
+    """Plot switching frequency time-series."""
+    if not time_list or not frequency_list:
+        return
+    
+    if sample_indices is None:
+        sample_indices = list(range(1, len(time_list) + 1))
+    
+    fig, ax = plt.subplots(figsize=(12, 6))
+    
+    for idx, (t_series, f_series) in enumerate(zip(time_list, frequency_list)):
+        if len(t_series) > 0 and len(f_series) > 0:
+            sample_no = sample_indices[idx] if idx < len(sample_indices) else idx + 1
+            ax.plot(t_series, f_series, marker='o', markersize=4, 
+                   label=f"No.{sample_no}", linewidth=2)
+    
+    ax.set_xlabel("Time (s)", fontsize=12)
+    ax.set_ylabel("Sign Reversal Frequency (1/s)", fontsize=12)
+    ax.set_title("Angular Velocity Sign-Reversal Frequency (Post-rise)", 
+                 fontsize=14, fontweight="bold")
+    ax.legend(loc="best", fontsize=10)
+    ax.grid(True, alpha=0.3)
+    
+    save_dir = f"{param.save_dir_bef}/{day}/repellent_response/03_post_rise_analysis/angular_velocity"
+    os.makedirs(save_dir, exist_ok=True)
+    
+    save_path = f"{save_dir}/switching_frequency.png"
+    fig.tight_layout()
+    fig.savefig(save_path, dpi=100)
+    plt.close(fig)

--- a/utils/functions/make_graph.py
+++ b/utils/functions/make_graph.py
@@ -1,5 +1,6 @@
 import math
 import os
+
 import matplotlib.gridspec as gridspec
 import matplotlib.pyplot as plt
 import numpy as np

--- a/utils/functions/make_graph.py
+++ b/utils/functions/make_graph.py
@@ -273,7 +273,6 @@ def plot_angular_velocity(angle_list, angular_velocity_list, day):
     rows = max(1, math.ceil(sample_num / cols))
     fig, axs = plt.subplots(rows, cols, figsize=(fig_size_x, fig_size_y * rows / 5))
     axs = np.atleast_2d(axs)
-    axs = np.atleast_2d(axs)
     for i in range(sample_num):
         row = i // cols
         col = i % cols

--- a/utils/functions/make_graph.py
+++ b/utils/functions/make_graph.py
@@ -1683,28 +1683,26 @@ def plot_angular_velocity_switching_frequency(
     """Plot switching frequency time-series."""
     if not time_list or not frequency_list:
         return
-    
+
     if sample_indices is None:
         sample_indices = list(range(1, len(time_list) + 1))
-    
+
     fig, ax = plt.subplots(figsize=(12, 6))
-    
+
     for idx, (t_series, f_series) in enumerate(zip(time_list, frequency_list)):
         if len(t_series) > 0 and len(f_series) > 0:
             sample_no = sample_indices[idx] if idx < len(sample_indices) else idx + 1
-            ax.plot(t_series, f_series, marker='o', markersize=4, 
-                   label=f"No.{sample_no}", linewidth=2)
-    
+            ax.plot(t_series, f_series, marker="o", markersize=4, label=f"No.{sample_no}", linewidth=2)
+
     ax.set_xlabel("Time (s)", fontsize=12)
     ax.set_ylabel("Sign Reversal Frequency (1/s)", fontsize=12)
-    ax.set_title("Angular Velocity Sign-Reversal Frequency (Post-rise)", 
-                 fontsize=14, fontweight="bold")
+    ax.set_title("Angular Velocity Sign-Reversal Frequency (Post-rise)", fontsize=14, fontweight="bold")
     ax.legend(loc="best", fontsize=10)
     ax.grid(True, alpha=0.3)
-    
+
     save_dir = f"{param.save_dir_bef}/{day}/repellent_response/03_post_rise_analysis/angular_velocity"
     os.makedirs(save_dir, exist_ok=True)
-    
+
     save_path = f"{save_dir}/switching_frequency.png"
     fig.tight_layout()
     fig.savefig(save_path, dpi=100)

--- a/utils/functions/make_graph.py
+++ b/utils/functions/make_graph.py
@@ -1,7 +1,5 @@
 import math
 import os
-from typing import Optional, Sequence
-
 import matplotlib.gridspec as gridspec
 import matplotlib.pyplot as plt
 import numpy as np
@@ -20,6 +18,14 @@ from utils.functions import (
 font_size = 20
 fig_size_x = 20
 fig_size_y = 23
+
+
+def _set_log_y_if_positive(ax, *series) -> None:
+    for values in series:
+        arr = np.asarray(values, dtype=float)
+        if np.any(np.isfinite(arr) & (arr > 0)):
+            ax.set_yscale("log")
+            return
 
 
 def plot_coordinate(x_list, y_list, day, mode):
@@ -528,8 +534,7 @@ def plot_fft(freq_list, Amp_list, save_dir, save_name, day, flag_add_peak=False)
         axs[row, col].set_xlabel("Frequency [Hz]", fontsize=font_size)
         axs[row, col].set_ylabel("Amp", fontsize=font_size)
         # axs[row, col].set_xscale("log")
-        if np.any(np.isfinite(amp_arr) & (amp_arr > 0)):
-            axs[row, col].set_yscale("log")
+        _set_log_y_if_positive(axs[row, col], amp_arr)
         axs[row, col].tick_params(axis="both", which="major", labelsize=font_size)
     plt.tight_layout()
     plt.savefig(f"{save_dir}/{save_name}")
@@ -675,7 +680,7 @@ def plot_SD_list_fft(freq_list, Amp_list, day, flag_std):
             axs[row, col].set_xlabel("Freqency [Hz]", fontsize=font_size)
             axs[row, col].set_ylabel("Amp", fontsize=font_size)
             # axs[row, col].set_xscale("log")
-            axs[row, col].set_yscale("log")
+            _set_log_y_if_positive(axs[row, col], Amp_list[j][i])
             axs[row, col].tick_params(axis="both", which="major", labelsize=font_size)
         plt.tight_layout()
         if flag_std:
@@ -706,7 +711,7 @@ def plot_SD_list_fft(freq_list, Amp_list, day, flag_std):
             axs[row, col].set_xlabel("Freqency [Hz]", fontsize=font_size)
             axs[row, col].set_ylabel("Amp", fontsize=font_size)
             # axs[row, col].set_xscale("log")
-            axs[row, col].set_yscale("log")
+            _set_log_y_if_positive(axs[row, col], Amp_list[j][i])
             axs[row, col].tick_params(axis="both", which="major", labelsize=font_size)
         axs[-1][-1].legend(plot_label_list, loc="upper left", bbox_to_anchor=(1, 1))
     plt.tight_layout()
@@ -1079,7 +1084,7 @@ def dev_plot_sd_FFT_with_rotation(freq_list, Amp_list, day):
         axs[row, col].set_xlabel("Freqency [Hz]", fontsize=font_size)
         axs[row, col].set_ylabel("Amp", fontsize=font_size)
         # axs[row, col].set_xscale("log")
-        axs[row, col].set_yscale("log")
+        _set_log_y_if_positive(axs[row, col], av_Amp_list[j], *[Amp_list[j][i] for i in range(len(width_time_list))])
         axs[row, col].tick_params(axis="both", which="major", labelsize=font_size)
 
     # SD
@@ -1108,10 +1113,22 @@ def dev_plot_fft_coordinates(X, Y, day):
     for i in range(sample_num):
         x_freq_list, x_Amp_list = frequency_analysis.fft(X[i], 1 / FrameRate[i])
         y_freq_list, y_Amp_list = frequency_analysis.fft(Y[i], 1 / FrameRate[i])
-        peak = max(x_freq_list[np.argmax(x_Amp_list)], y_freq_list[np.argmax(y_Amp_list)])
+        peak_candidates = []
+        if x_freq_list.size > 0 and x_Amp_list.size > 0 and np.isfinite(x_Amp_list).any():
+            peak_candidates.append(float(x_freq_list[int(np.nanargmax(x_Amp_list))]))
+        if y_freq_list.size > 0 and y_Amp_list.size > 0 and np.isfinite(y_Amp_list).any():
+            peak_candidates.append(float(y_freq_list[int(np.nanargmax(y_Amp_list))]))
+        if peak_candidates:
+            peak = max(peak_candidates)
+        else:
+            peak = 0.1
 
         row = i // cols
         col = i % cols
+        if x_freq_list.size == 0 or y_freq_list.size == 0:
+            axs[row, 2 * col].axis("off")
+            axs[row, 2 * col + 1].axis("off")
+            continue
         axs[row, 2 * col].plot(x_freq_list, x_Amp_list)
         axs[row, 2 * col + 1].plot(y_freq_list, y_Amp_list)
         axs[row, 2 * col].set_xlim(0, x_freq_list[-1])
@@ -1126,7 +1143,7 @@ def dev_plot_fft_coordinates(X, Y, day):
             )
             axs[row, 2 * col + j].set_xlabel("Freqency [Hz]", fontsize=font_size)
             axs[row, 2 * col + j].set_ylabel("Amp", fontsize=font_size)
-            axs[row, 2 * col + j].set_yscale("log")
+            _set_log_y_if_positive(axs[row, 2 * col + j], x_Amp_list if j == 0 else y_Amp_list)
             axs[row, 2 * col + j].tick_params(axis="both", which="major", labelsize=font_size)
     plt.tight_layout()
     plt.savefig(f"{save_dir}/{save_name}")

--- a/utils/functions/make_graph.py
+++ b/utils/functions/make_graph.py
@@ -1501,8 +1501,6 @@ def plot_repellent_component_panels(
     cols = 3  # x-y, x-t, y-t
     fig, axs = plt.subplots(rows, cols, figsize=(3 * fig_size_x / 2, max(6, rows * 4)))
     axs = np.atleast_2d(axs)
-    if rows == 1:
-        axs = np.array([axs])
 
     for i in range(rows):
         x_arr = np.asarray(x_list[i], dtype=float)

--- a/utils/functions/repellent_response.py
+++ b/utils/functions/repellent_response.py
@@ -63,41 +63,6 @@ def _get_top_right_roi_mean(frame_arr: np.ndarray, roi_size: int = 10) -> float:
         frame_arr = frame_arr[..., 0]
 
     h, w = frame_arr.shape[:2]
-    roi_h = min(roi_size, h)
-    roi_w = min(roi_size, w)
-    if roi_h <= 0 or roi_w <= 0:
-        return np.nan
-
-    roi = frame_arr[:roi_h, w - roi_w : w]
-    return float(np.mean(roi))
-
-
-def _load_brightness_data_mean_series(
-    day: str,
-    sample_name: str,
-    ref_time_list: Sequence[float],
-) -> List[float]:
-    csv_path = f"{param.input_dir_bef}/{day}/brightness_data/{sample_name}.csv"
-    if not os.path.isfile(csv_path):
-        raise FileNotFoundError(f"brightness_data csv not found: {csv_path}")
-
-    df = pd.read_csv(csv_path)
-
-    if "Mean" not in df.columns:
-        raise KeyError(f"'Mean' column not found in {csv_path}")
-    if "[inch]" not in df.columns:
-        raise KeyError(f"'[inch]' column not found in {csv_path}")
-
-    mean_arr = pd.to_numeric(df["Mean"], errors="coerce").to_numpy(dtype=float)
-    n = min(len(mean_arr), len(ref_time_list))
-    return mean_arr[:n].tolist()
-
-
-def _get_top_right_roi_mean(frame_arr: np.ndarray, roi_size: int = 10) -> float:
-    if frame_arr.ndim >= 3:
-        frame_arr = frame_arr[..., 0]
-
-    h, w = frame_arr.shape[:2]
     if h <= 0 or w <= 0:
         return float(np.nan)
 
@@ -150,12 +115,12 @@ def get_background_intensity_time_series(day: str, roi_size: int = 10) -> List[L
             target_len = len(time_list[idx])
 
         if flag_use_brightness_data:
-            sample_bg = _load_brightness_data_mean_series(
+            brightness_bg = _load_brightness_data_mean_series(
                 day=day,
                 sample_name=sample_name,
                 target_len=target_len,
             )
-            background_list.append(sample_bg)
+            background_list.append(brightness_bg)
             continue
 
         sample_dir = os.path.join(tiff_root, sample_name)
@@ -168,18 +133,18 @@ def get_background_intensity_time_series(day: str, roi_size: int = 10) -> List[L
         ]
         frame_names = sorted(frame_names, key=_safe_extract_number)
 
-        sample_bg: List[float] = []
+        roi_bg: List[float] = []
         for frame_name in frame_names:
             frame_path = os.path.join(sample_dir, frame_name)
             with Image.open(frame_path) as img:
                 frame_arr = np.asarray(img)
 
-            sample_bg.append(_get_top_right_roi_mean(frame_arr, roi_size=roi_size))
+            roi_bg.append(_get_top_right_roi_mean(frame_arr, roi_size=roi_size))
 
         if target_len is not None:
-            sample_bg = sample_bg[: min(len(sample_bg), target_len)]
+            roi_bg = roi_bg[: min(len(roi_bg), target_len)]
 
-        background_list.append(sample_bg)
+        background_list.append(roi_bg)
 
     return background_list
 

--- a/utils/functions/repellent_response.py
+++ b/utils/functions/repellent_response.py
@@ -64,7 +64,22 @@ def ensure_repellent_config(day: str, default_frame_rate: float = 200.0, default
     cfg = configparser.ConfigParser()
     if os.path.isfile(config_path):
         cfg.read(config_path)
+
+        changed = False
+        if not cfg.has_section("RepellentResponse"):
+            cfg.add_section("RepellentResponse")
+            changed = True
+        if not cfg.has_option("RepellentResponse", "post_rise_center_mode"):
+            cfg.set("RepellentResponse", "post_rise_center_mode", "2")
+            changed = True
+        if not cfg.has_option("RepellentResponse", "flag_use_brightness_data"):
+            cfg.set("RepellentResponse", "flag_use_brightness_data", "False")
+            changed = True
+
         if cfg.has_section("Settings") and cfg.has_section("Tiff_info"):
+            if changed:
+                with open(config_path, "w", encoding="utf-8") as fp:
+                    cfg.write(fp)
             return config_path
 
     input_dir = f"{param.input_dir_bef}/{day}"
@@ -92,10 +107,48 @@ def ensure_repellent_config(day: str, default_frame_rate: float = 200.0, default
         "px2um_y": str(default_px2um),
     }
     cfg["Tiff_info"] = {"tiff_data": ", ".join(tiff_names)}
-    cfg["RepellentResponse"] = {"post_rise_center_mode": "2"}
+    cfg["RepellentResponse"] = {
+        "post_rise_center_mode": "2",
+        "flag_use_brightness_data": "False",
+    }
     with open(config_path, "w", encoding="utf-8") as fp:
         cfg.write(fp)
     return config_path
+
+
+def _get_top_right_roi_mean(frame_arr: np.ndarray, roi_size: int = 10) -> float:
+    if frame_arr.ndim >= 3:
+        frame_arr = frame_arr[..., 0]
+
+    h, w = frame_arr.shape[:2]
+    roi_h = min(roi_size, h)
+    roi_w = min(roi_size, w)
+    if roi_h <= 0 or roi_w <= 0:
+        return np.nan
+
+    roi = frame_arr[:roi_h, w - roi_w : w]
+    return float(np.mean(roi))
+
+
+def _load_brightness_data_mean_series(
+    day: str,
+    sample_name: str,
+    ref_time_list: Sequence[float],
+) -> List[float]:
+    csv_path = f"{param.input_dir_bef}/{day}/brightness_data/{sample_name}.csv"
+    if not os.path.isfile(csv_path):
+        raise FileNotFoundError(f"brightness_data csv not found: {csv_path}")
+
+    df = pd.read_csv(csv_path)
+
+    if "Mean" not in df.columns:
+        raise KeyError(f"'Mean' column not found in {csv_path}")
+    if "[inch]" not in df.columns:
+        raise KeyError(f"'[inch]' column not found in {csv_path}")
+
+    mean_arr = pd.to_numeric(df["Mean"], errors="coerce").to_numpy(dtype=float)
+    n = min(len(mean_arr), len(ref_time_list))
+    return mean_arr[:n].tolist()
 
 
 def get_post_rise_center_mode(day: str, default_mode: int = 2) -> int:
@@ -130,42 +183,30 @@ def get_post_rise_center_mode(day: str, default_mode: int = 2) -> int:
 
 
 def get_background_intensity_time_series(day: str, roi_size: int = 10) -> List[List[float]]:
-    """Extract background intensity using mean centroid-based ROI."""
-    tiff_root = f"{param.input_dir_bef}/{day}/tiff_data"
+    """Extract background intensity from either top-right ROI or brightness_data CSV."""
     sample_names = get_tiff_sample_names(day)
     background_list: List[List[float]] = []
-    
-    try:
-        px2um_x, px2um_y = param.get_px2um_config(day)
-    except Exception:
-        px2um_x, px2um_y = 1.0, 1.0
-    
-    try:
-        x_center_list, y_center_list = load_centroid_coordinate_with_nan(day)
-    except Exception:
-        x_center_list, y_center_list = [], []
 
-    for idx, sample_name in enumerate(sample_names):
+    flag_use_brightness_data = param.get_flag_use_brightness_data(day)
+
+    if flag_use_brightness_data:
+        time_list = ensure_time_list(day)
+        for idx, sample_name in enumerate(sample_names):
+            if idx >= len(time_list):
+                raise IndexError(
+                    f"time_list does not contain sample index {idx} for sample '{sample_name}'"
+                )
+            sample_bg = _load_brightness_data_mean_series(
+                day=day,
+                sample_name=sample_name,
+                ref_time_list=time_list[idx],
+            )
+            background_list.append(sample_bg)
+        return background_list
+
+    tiff_root = f"{param.input_dir_bef}/{day}/tiff_data"
+    for sample_name in sample_names:
         sample_dir = os.path.join(tiff_root, sample_name)
-        
-        if idx < len(x_center_list) and idx < len(y_center_list):
-            x_center_arr = np.asarray(x_center_list[idx], dtype=float)
-            y_center_arr = np.asarray(y_center_list[idx], dtype=float)
-            x_center_arr = x_center_arr[np.isfinite(x_center_arr)]
-            y_center_arr = y_center_arr[np.isfinite(y_center_arr)]
-            
-            if len(x_center_arr) > 0 and len(y_center_arr) > 0:
-                mean_x = float(np.mean(x_center_arr))
-                mean_y = float(np.mean(y_center_arr))
-            else:
-                mean_x, mean_y = 0.0, 0.0
-        else:
-            mean_x, mean_y = 0.0, 0.0
-        
-        offset_px = int(param.bg_roi_offset_um_downward / max(px2um_y, 0.1))
-        roi_center_y = int(mean_y + offset_px)
-        roi_center_x = int(mean_x)
-        
         if not os.path.isdir(sample_dir):
             background_list.append([])
             continue
@@ -180,23 +221,10 @@ def get_background_intensity_time_series(day: str, roi_size: int = 10) -> List[L
             frame_path = os.path.join(sample_dir, frame_name)
             with Image.open(frame_path) as img:
                 frame_arr = np.asarray(img)
-            if frame_arr.ndim >= 3:
-                frame_arr = frame_arr[..., 0]
-            
-            h, w = frame_arr.shape[:2]
-            roi_top = max(0, roi_center_y - roi_size // 2)
-            roi_bottom = min(h, roi_center_y + (roi_size - roi_size // 2))
-            roi_left = max(0, roi_center_x - roi_size // 2)
-            roi_right = min(w, roi_center_x + (roi_size - roi_size // 2))
-            
-            if roi_top < roi_bottom and roi_left < roi_right:
-                roi = frame_arr[roi_top:roi_bottom, roi_left:roi_right]
-                sample_bg.append(float(np.mean(roi)))
-            else:
-                sample_bg.append(np.nan)
-        
+            sample_bg.append(_get_top_right_roi_mean(frame_arr, roi_size=roi_size))
+
         background_list.append(sample_bg)
-    
+
     return background_list
 
 
@@ -207,57 +235,67 @@ def calculate_angular_velocity_switching_frequency(
     window_shift_sec: float = 0.5,
 ) -> Tuple[List[List[float]], List[List[float]]]:
     """Calculate sign-reversal frequency using sliding windows."""
-    out_time = []
-    out_freq = []
-    
+    out_time: List[List[float]] = []
+    out_freq: List[List[float]] = []
+
     for time_arr, av_arr in zip(time_list, angular_velocity_list):
         if len(time_arr) < 2 or len(av_arr) < 2:
             out_time.append([])
             out_freq.append([])
             continue
-        
+
         t = np.asarray(time_arr, dtype=float)
         av = np.asarray(av_arr, dtype=float)
-        
+
+        # time と angular velocity の長さ差を吸収
+        n = min(len(t), len(av))
+        if n < 2:
+            out_time.append([])
+            out_freq.append([])
+            continue
+
+        t = t[:n]
+        av = av[:n]
+
         valid_mask = np.isfinite(t) & np.isfinite(av)
         if np.sum(valid_mask) < 2:
             out_time.append([])
             out_freq.append([])
             continue
-        
+
         t = t[valid_mask]
         av = av[valid_mask]
-        
+
         if len(t) < 2 or len(av) < 2:
             out_time.append([])
             out_freq.append([])
             continue
-        
-        w_times = []
-        w_freqs = []
-        
+
+        w_times: List[float] = []
+        w_freqs: List[float] = []
+
         t_start = float(t[0])
         t_end = float(t[-1])
         current_time = t_start
-        
+
         while current_time + window_width_sec <= t_end:
             window_end = current_time + window_width_sec
             window_mask = (t >= current_time) & (t <= window_end)
-            
+
             if np.sum(window_mask) >= 2:
                 window_av = av[window_mask]
                 sign_changes = np.sum(np.diff(np.sign(window_av)) != 0)
                 frequency = float(sign_changes) / window_width_sec
-                
+
                 window_center_time = float(current_time + window_width_sec / 2.0)
                 w_times.append(window_center_time)
                 w_freqs.append(frequency)
-            
+
             current_time += window_shift_sec
-        
+
         out_time.append(w_times)
         out_freq.append(w_freqs)
-    
+
     return out_time, out_freq
 
 

--- a/utils/functions/repellent_response.py
+++ b/utils/functions/repellent_response.py
@@ -201,20 +201,24 @@ def calculate_angular_velocity_switching_count(
         w_times: List[float] = []
         w_counts: List[float] = []
 
-        for start_idx in range(len(t)):
+        end_idx = 1
+        for start_idx in range(len(t) - 1):
             window_start = float(t[start_idx])
             window_end = window_start + window_width_sec
-            window_mask = (t >= window_start) & (t <= window_end)
 
-            if np.sum(window_mask) < 2:
+            if end_idx < start_idx + 1:
+                end_idx = start_idx + 1
+            while end_idx < len(t) and t[end_idx] <= window_end:
+                end_idx += 1
+
+            if end_idx - start_idx < 2:
                 continue
 
-            window_av = av[window_mask]
+            window_av = av[start_idx:end_idx]
             switch_count = _count_sign_switches(window_av)
 
             w_times.append(window_start + window_width_sec / 2.0)
             w_counts.append(float(switch_count))
-
         out_time.append(w_times)
         out_count.append(w_counts)
 

--- a/utils/functions/repellent_response.py
+++ b/utils/functions/repellent_response.py
@@ -58,60 +58,6 @@ def get_tiff_sample_names(day: str) -> List[str]:
     return sorted([name for name in os.listdir(tiff_root) if os.path.isdir(os.path.join(tiff_root, name))])
 
 
-def ensure_repellent_config(day: str, default_frame_rate: float = 200.0, default_px2um: float = 1.0) -> str:
-    config_path = f"{param.input_dir_bef}/{day}/config.ini"
-
-    cfg = configparser.ConfigParser()
-    changed = False
-
-    if os.path.isfile(config_path):
-        cfg.read(config_path)
-    else:
-        input_dir = f"{param.input_dir_bef}/{day}"
-        avi_names = sorted([name for name in os.listdir(input_dir) if name.lower().endswith(".avi")])
-        sample_num = len(avi_names)
-        if sample_num == 0:
-            raise FileNotFoundError(f"No .avi file found in {input_dir}")
-
-        tiff_names = get_tiff_sample_names(day)
-        if len(tiff_names) == 0:
-            raise FileNotFoundError(f"No tiff sample directory found in {input_dir}/tiff_data")
-
-        if len(tiff_names) < sample_num:
-            tiff_names = tiff_names + [tiff_names[-1]] * (sample_num - len(tiff_names))
-        else:
-            tiff_names = tiff_names[:sample_num]
-
-        cfg["Settings"] = {
-            "sample_num": str(sample_num),
-            "FrameRate": str(default_frame_rate),
-            "total_time": "1",
-            "flag_use_tiff_log": "True",
-            "px2um_x": str(default_px2um),
-            "px2um_y": str(default_px2um),
-        }
-        cfg["Tiff_info"] = {"tiff_data": ", ".join(tiff_names)}
-        changed = True
-
-    if not cfg.has_section("RepellentResponse"):
-        cfg.add_section("RepellentResponse")
-        changed = True
-
-    if not cfg.has_option("RepellentResponse", "post_rise_center_mode"):
-        cfg.set("RepellentResponse", "post_rise_center_mode", "2")
-        changed = True
-
-    if not cfg.has_option("RepellentResponse", "flag_use_brightness_data"):
-        cfg.set("RepellentResponse", "flag_use_brightness_data", "False")
-        changed = True
-
-    if changed:
-        with open(config_path, "w", encoding="utf-8") as fp:
-            cfg.write(fp)
-
-    return config_path
-
-
 def _get_top_right_roi_mean(frame_arr: np.ndarray, roi_size: int = 10) -> float:
     if frame_arr.ndim >= 3:
         frame_arr = frame_arr[..., 0]
@@ -145,37 +91,6 @@ def _load_brightness_data_mean_series(
     mean_arr = pd.to_numeric(df["Mean"], errors="coerce").to_numpy(dtype=float)
     n = min(len(mean_arr), len(ref_time_list))
     return mean_arr[:n].tolist()
-
-
-def get_post_rise_center_mode(day: str, default_mode: int = 2) -> int:
-    config_path = f"{param.input_dir_bef}/{day}/config.ini"
-    cfg = configparser.ConfigParser()
-    cfg.read(config_path)
-
-    section = "RepellentResponse"
-    changed = False
-    if not cfg.has_section(section):
-        cfg.add_section(section)
-        changed = True
-    if not cfg.has_option(section, "post_rise_center_mode"):
-        cfg.set(section, "post_rise_center_mode", str(default_mode))
-        changed = True
-
-    raw_mode = cfg.get(section, "post_rise_center_mode", fallback=str(default_mode))
-    try:
-        mode = int(raw_mode)
-    except (ValueError, TypeError):
-        mode = int(default_mode)
-    if mode not in (1, 2, 3):
-        mode = int(default_mode)
-    if cfg.get(section, "post_rise_center_mode", fallback="") != str(mode):
-        cfg.set(section, "post_rise_center_mode", str(mode))
-        changed = True
-
-    if changed:
-        with open(config_path, "w", encoding="utf-8") as fp:
-            cfg.write(fp)
-    return mode
 
 
 def _get_top_right_roi_mean(frame_arr: np.ndarray, roi_size: int = 10) -> float:
@@ -219,9 +134,13 @@ def _load_brightness_data_mean_series(day: str, sample_name: str, target_len: Op
 def get_background_intensity_time_series(day: str, roi_size: int = 10) -> List[List[float]]:
     """Extract background intensity from brightness_data CSV or top-right fixed ROI."""
     tiff_root = f"{param.input_dir_bef}/{day}/tiff_data"
+    brightness_root = f"{param.input_dir_bef}/{day}/brightness_data"
     sample_names = get_tiff_sample_names(day)
     time_list = ensure_time_list(day)
     flag_use_brightness_data = param.get_flag_use_brightness_data(day, default_flag=False)
+
+    if flag_use_brightness_data and not os.path.isdir(brightness_root):
+        raise FileNotFoundError(f"brightness_data directory not found: {brightness_root}")
 
     background_list: List[List[float]] = []
 

--- a/utils/functions/repellent_response.py
+++ b/utils/functions/repellent_response.py
@@ -130,12 +130,42 @@ def get_post_rise_center_mode(day: str, default_mode: int = 2) -> int:
 
 
 def get_background_intensity_time_series(day: str, roi_size: int = 10) -> List[List[float]]:
+    """Extract background intensity using mean centroid-based ROI."""
     tiff_root = f"{param.input_dir_bef}/{day}/tiff_data"
     sample_names = get_tiff_sample_names(day)
     background_list: List[List[float]] = []
+    
+    try:
+        px2um_x, px2um_y = param.get_px2um_config(day)
+    except Exception:
+        px2um_x, px2um_y = 1.0, 1.0
+    
+    try:
+        x_center_list, y_center_list = load_centroid_coordinate_with_nan(day)
+    except Exception:
+        x_center_list, y_center_list = [], []
 
-    for sample_name in sample_names:
+    for idx, sample_name in enumerate(sample_names):
         sample_dir = os.path.join(tiff_root, sample_name)
+        
+        if idx < len(x_center_list) and idx < len(y_center_list):
+            x_center_arr = np.asarray(x_center_list[idx], dtype=float)
+            y_center_arr = np.asarray(y_center_list[idx], dtype=float)
+            x_center_arr = x_center_arr[np.isfinite(x_center_arr)]
+            y_center_arr = y_center_arr[np.isfinite(y_center_arr)]
+            
+            if len(x_center_arr) > 0 and len(y_center_arr) > 0:
+                mean_x = float(np.mean(x_center_arr))
+                mean_y = float(np.mean(y_center_arr))
+            else:
+                mean_x, mean_y = 0.0, 0.0
+        else:
+            mean_x, mean_y = 0.0, 0.0
+        
+        offset_px = int(param.bg_roi_offset_um_downward / max(px2um_y, 0.1))
+        roi_center_y = int(mean_y + offset_px)
+        roi_center_x = int(mean_x)
+        
         if not os.path.isdir(sample_dir):
             background_list.append([])
             continue
@@ -152,13 +182,83 @@ def get_background_intensity_time_series(day: str, roi_size: int = 10) -> List[L
                 frame_arr = np.asarray(img)
             if frame_arr.ndim >= 3:
                 frame_arr = frame_arr[..., 0]
+            
             h, w = frame_arr.shape[:2]
-            roi_h = min(roi_size, h)
-            roi_w = min(roi_size, w)
-            roi = frame_arr[:roi_h, w - roi_w : w]
-            sample_bg.append(float(np.mean(roi)))
+            roi_top = max(0, roi_center_y - roi_size // 2)
+            roi_bottom = min(h, roi_center_y + (roi_size - roi_size // 2))
+            roi_left = max(0, roi_center_x - roi_size // 2)
+            roi_right = min(w, roi_center_x + (roi_size - roi_size // 2))
+            
+            if roi_top < roi_bottom and roi_left < roi_right:
+                roi = frame_arr[roi_top:roi_bottom, roi_left:roi_right]
+                sample_bg.append(float(np.mean(roi)))
+            else:
+                sample_bg.append(np.nan)
+        
         background_list.append(sample_bg)
+    
     return background_list
+
+
+def calculate_angular_velocity_switching_frequency(
+    time_list: Sequence[Sequence[float]],
+    angular_velocity_list: Sequence[Sequence[float]],
+    window_width_sec: float = 2.0,
+    window_shift_sec: float = 0.5,
+) -> Tuple[List[List[float]], List[List[float]]]:
+    """Calculate sign-reversal frequency using sliding windows."""
+    out_time = []
+    out_freq = []
+    
+    for time_arr, av_arr in zip(time_list, angular_velocity_list):
+        if len(time_arr) < 2 or len(av_arr) < 2:
+            out_time.append([])
+            out_freq.append([])
+            continue
+        
+        t = np.asarray(time_arr, dtype=float)
+        av = np.asarray(av_arr, dtype=float)
+        
+        valid_mask = np.isfinite(t) & np.isfinite(av)
+        if np.sum(valid_mask) < 2:
+            out_time.append([])
+            out_freq.append([])
+            continue
+        
+        t = t[valid_mask]
+        av = av[valid_mask]
+        
+        if len(t) < 2 or len(av) < 2:
+            out_time.append([])
+            out_freq.append([])
+            continue
+        
+        w_times = []
+        w_freqs = []
+        
+        t_start = float(t[0])
+        t_end = float(t[-1])
+        current_time = t_start
+        
+        while current_time + window_width_sec <= t_end:
+            window_end = current_time + window_width_sec
+            window_mask = (t >= current_time) & (t <= window_end)
+            
+            if np.sum(window_mask) >= 2:
+                window_av = av[window_mask]
+                sign_changes = np.sum(np.diff(np.sign(window_av)) != 0)
+                frequency = float(sign_changes) / window_width_sec
+                
+                window_center_time = float(current_time + window_width_sec / 2.0)
+                w_times.append(window_center_time)
+                w_freqs.append(frequency)
+            
+            current_time += window_shift_sec
+        
+        out_time.append(w_times)
+        out_freq.append(w_freqs)
+    
+    return out_time, out_freq
 
 
 def detect_rise_index(

--- a/utils/functions/repellent_response.py
+++ b/utils/functions/repellent_response.py
@@ -203,7 +203,7 @@ def _load_brightness_data_mean_series(day: str, sample_name: str, target_len: Op
 
     df = pd.read_csv(csv_path)
 
-    required_columns = ['[inch]', 'Mean']
+    required_columns = ["[inch]", "Mean"]
     for col in required_columns:
         if col not in df.columns:
             raise ValueError(f"Required column '{col}' not found in {csv_path}")
@@ -245,8 +245,7 @@ def get_background_intensity_time_series(day: str, roi_size: int = 10) -> List[L
             continue
 
         frame_names = [
-            name for name in os.listdir(sample_dir)
-            if name.lower().endswith(".tif") or name.lower().endswith(".tiff")
+            name for name in os.listdir(sample_dir) if name.lower().endswith(".tif") or name.lower().endswith(".tiff")
         ]
         frame_names = sorted(frame_names, key=_safe_extract_number)
 

--- a/utils/functions/repellent_response.py
+++ b/utils/functions/repellent_response.py
@@ -62,57 +62,53 @@ def ensure_repellent_config(day: str, default_frame_rate: float = 200.0, default
     config_path = f"{param.input_dir_bef}/{day}/config.ini"
 
     cfg = configparser.ConfigParser()
+    changed = False
+
     if os.path.isfile(config_path):
         cfg.read(config_path)
-
-        changed = False
-        if not cfg.has_section("RepellentResponse"):
-            cfg.add_section("RepellentResponse")
-            changed = True
-        if not cfg.has_option("RepellentResponse", "post_rise_center_mode"):
-            cfg.set("RepellentResponse", "post_rise_center_mode", "2")
-            changed = True
-        if not cfg.has_option("RepellentResponse", "flag_use_brightness_data"):
-            cfg.set("RepellentResponse", "flag_use_brightness_data", "False")
-            changed = True
-
-        if cfg.has_section("Settings") and cfg.has_section("Tiff_info"):
-            if changed:
-                with open(config_path, "w", encoding="utf-8") as fp:
-                    cfg.write(fp)
-            return config_path
-
-    input_dir = f"{param.input_dir_bef}/{day}"
-    avi_names = sorted([name for name in os.listdir(input_dir) if name.lower().endswith(".avi")])
-    sample_num = len(avi_names)
-    if sample_num == 0:
-        raise FileNotFoundError(f"No .avi file found in {input_dir}")
-
-    tiff_names = get_tiff_sample_names(day)
-    if len(tiff_names) == 0:
-        raise FileNotFoundError(f"No tiff sample directory found in {input_dir}/tiff_data")
-
-    if len(tiff_names) < sample_num:
-        tiff_names = tiff_names + [tiff_names[-1]] * (sample_num - len(tiff_names))
     else:
-        tiff_names = tiff_names[:sample_num]
+        input_dir = f"{param.input_dir_bef}/{day}"
+        avi_names = sorted([name for name in os.listdir(input_dir) if name.lower().endswith(".avi")])
+        sample_num = len(avi_names)
+        if sample_num == 0:
+            raise FileNotFoundError(f"No .avi file found in {input_dir}")
 
-    cfg = configparser.ConfigParser()
-    cfg["Settings"] = {
-        "sample_num": str(sample_num),
-        "FrameRate": str(default_frame_rate),
-        "total_time": "1",
-        "flag_use_tiff_log": "True",
-        "px2um_x": str(default_px2um),
-        "px2um_y": str(default_px2um),
-    }
-    cfg["Tiff_info"] = {"tiff_data": ", ".join(tiff_names)}
-    cfg["RepellentResponse"] = {
-        "post_rise_center_mode": "2",
-        "flag_use_brightness_data": "False",
-    }
-    with open(config_path, "w", encoding="utf-8") as fp:
-        cfg.write(fp)
+        tiff_names = get_tiff_sample_names(day)
+        if len(tiff_names) == 0:
+            raise FileNotFoundError(f"No tiff sample directory found in {input_dir}/tiff_data")
+
+        if len(tiff_names) < sample_num:
+            tiff_names = tiff_names + [tiff_names[-1]] * (sample_num - len(tiff_names))
+        else:
+            tiff_names = tiff_names[:sample_num]
+
+        cfg["Settings"] = {
+            "sample_num": str(sample_num),
+            "FrameRate": str(default_frame_rate),
+            "total_time": "1",
+            "flag_use_tiff_log": "True",
+            "px2um_x": str(default_px2um),
+            "px2um_y": str(default_px2um),
+        }
+        cfg["Tiff_info"] = {"tiff_data": ", ".join(tiff_names)}
+        changed = True
+
+    if not cfg.has_section("RepellentResponse"):
+        cfg.add_section("RepellentResponse")
+        changed = True
+
+    if not cfg.has_option("RepellentResponse", "post_rise_center_mode"):
+        cfg.set("RepellentResponse", "post_rise_center_mode", "2")
+        changed = True
+
+    if not cfg.has_option("RepellentResponse", "flag_use_brightness_data"):
+        cfg.set("RepellentResponse", "flag_use_brightness_data", "False")
+        changed = True
+
+    if changed:
+        with open(config_path, "w", encoding="utf-8") as fp:
+            cfg.write(fp)
+
     return config_path
 
 
@@ -182,37 +178,75 @@ def get_post_rise_center_mode(day: str, default_mode: int = 2) -> int:
     return mode
 
 
+def _get_top_right_roi_mean(frame_arr: np.ndarray, roi_size: int = 10) -> float:
+    if frame_arr.ndim >= 3:
+        frame_arr = frame_arr[..., 0]
+
+    h, w = frame_arr.shape[:2]
+    if h <= 0 or w <= 0:
+        return float(np.nan)
+
+    roi_h = min(roi_size, h)
+    roi_w = min(roi_size, w)
+    roi = frame_arr[:roi_h, w - roi_w : w]
+
+    if roi.size == 0:
+        return float(np.nan)
+
+    return float(np.mean(roi))
+
+
+def _load_brightness_data_mean_series(day: str, sample_name: str, target_len: Optional[int] = None) -> List[float]:
+    csv_path = f"{param.input_dir_bef}/{day}/brightness_data/{sample_name}.csv"
+    if not os.path.isfile(csv_path):
+        raise FileNotFoundError(f"brightness_data csv not found: {csv_path}")
+
+    df = pd.read_csv(csv_path)
+
+    required_columns = ['[inch]', 'Mean']
+    for col in required_columns:
+        if col not in df.columns:
+            raise ValueError(f"Required column '{col}' not found in {csv_path}")
+
+    mean_arr = pd.to_numeric(df["Mean"], errors="coerce").to_numpy(dtype=float)
+
+    if target_len is not None:
+        mean_arr = mean_arr[: min(len(mean_arr), target_len)]
+
+    return mean_arr.tolist()
+
+
 def get_background_intensity_time_series(day: str, roi_size: int = 10) -> List[List[float]]:
-    """Extract background intensity from either top-right ROI or brightness_data CSV."""
+    """Extract background intensity from brightness_data CSV or top-right fixed ROI."""
+    tiff_root = f"{param.input_dir_bef}/{day}/tiff_data"
     sample_names = get_tiff_sample_names(day)
+    time_list = ensure_time_list(day)
+    flag_use_brightness_data = param.get_flag_use_brightness_data(day, default_flag=False)
+
     background_list: List[List[float]] = []
 
-    flag_use_brightness_data = param.get_flag_use_brightness_data(day)
+    for idx, sample_name in enumerate(sample_names):
+        target_len: Optional[int] = None
+        if idx < len(time_list):
+            target_len = len(time_list[idx])
 
-    if flag_use_brightness_data:
-        time_list = ensure_time_list(day)
-        for idx, sample_name in enumerate(sample_names):
-            if idx >= len(time_list):
-                raise IndexError(
-                    f"time_list does not contain sample index {idx} for sample '{sample_name}'"
-                )
+        if flag_use_brightness_data:
             sample_bg = _load_brightness_data_mean_series(
                 day=day,
                 sample_name=sample_name,
-                ref_time_list=time_list[idx],
+                target_len=target_len,
             )
             background_list.append(sample_bg)
-        return background_list
+            continue
 
-    tiff_root = f"{param.input_dir_bef}/{day}/tiff_data"
-    for sample_name in sample_names:
         sample_dir = os.path.join(tiff_root, sample_name)
         if not os.path.isdir(sample_dir):
             background_list.append([])
             continue
 
         frame_names = [
-            name for name in os.listdir(sample_dir) if name.lower().endswith(".tif") or name.lower().endswith(".tiff")
+            name for name in os.listdir(sample_dir)
+            if name.lower().endswith(".tif") or name.lower().endswith(".tiff")
         ]
         frame_names = sorted(frame_names, key=_safe_extract_number)
 
@@ -221,7 +255,11 @@ def get_background_intensity_time_series(day: str, roi_size: int = 10) -> List[L
             frame_path = os.path.join(sample_dir, frame_name)
             with Image.open(frame_path) as img:
                 frame_arr = np.asarray(img)
+
             sample_bg.append(_get_top_right_roi_mean(frame_arr, roi_size=roi_size))
+
+        if target_len is not None:
+            sample_bg = sample_bg[: min(len(sample_bg), target_len)]
 
         background_list.append(sample_bg)
 
@@ -247,7 +285,6 @@ def calculate_angular_velocity_switching_frequency(
         t = np.asarray(time_arr, dtype=float)
         av = np.asarray(av_arr, dtype=float)
 
-        # time と angular velocity の長さ差を吸収
         n = min(len(t), len(av))
         if n < 2:
             out_time.append([])

--- a/utils/functions/repellent_response.py
+++ b/utils/functions/repellent_response.py
@@ -265,74 +265,76 @@ def get_background_intensity_time_series(day: str, roi_size: int = 10) -> List[L
     return background_list
 
 
-def calculate_angular_velocity_switching_frequency(
+def _count_sign_switches(values: np.ndarray) -> int:
+    sign_arr = np.sign(values)
+    sign_arr = sign_arr[np.isfinite(sign_arr)]
+    sign_arr = sign_arr[sign_arr != 0]
+
+    if sign_arr.size < 2:
+        return 0
+
+    return int(np.sum(np.diff(sign_arr) != 0))
+
+
+def calculate_angular_velocity_switching_count(
     time_list: Sequence[Sequence[float]],
     angular_velocity_list: Sequence[Sequence[float]],
-    window_width_sec: float = 2.0,
-    window_shift_sec: float = 0.5,
+    window_width_sec: float = 1.0,
 ) -> Tuple[List[List[float]], List[List[float]]]:
-    """Calculate sign-reversal frequency using sliding windows."""
+    """
+    Calculate sign-switching count in sliding windows.
+
+    - Use all-time angular velocity series.
+    - Window width is fixed in seconds.
+    - Window shift is 1 data point (i.e. 1 / FrameRate when sampling is regular).
+    - Each output time is the center time of the window.
+    """
     out_time: List[List[float]] = []
-    out_freq: List[List[float]] = []
+    out_count: List[List[float]] = []
 
     for time_arr, av_arr in zip(time_list, angular_velocity_list):
-        if len(time_arr) < 2 or len(av_arr) < 2:
-            out_time.append([])
-            out_freq.append([])
-            continue
-
         t = np.asarray(time_arr, dtype=float)
         av = np.asarray(av_arr, dtype=float)
 
         n = min(len(t), len(av))
         if n < 2:
             out_time.append([])
-            out_freq.append([])
+            out_count.append([])
             continue
 
         t = t[:n]
         av = av[:n]
 
         valid_mask = np.isfinite(t) & np.isfinite(av)
-        if np.sum(valid_mask) < 2:
-            out_time.append([])
-            out_freq.append([])
-            continue
-
         t = t[valid_mask]
         av = av[valid_mask]
 
-        if len(t) < 2 or len(av) < 2:
+        if len(t) < 2:
             out_time.append([])
-            out_freq.append([])
+            out_count.append([])
             continue
 
         w_times: List[float] = []
-        w_freqs: List[float] = []
+        w_counts: List[float] = []
 
-        t_start = float(t[0])
-        t_end = float(t[-1])
-        current_time = t_start
+        for start_idx in range(len(t)):
+            window_start = float(t[start_idx])
+            window_end = window_start + window_width_sec
+            window_mask = (t >= window_start) & (t <= window_end)
 
-        while current_time + window_width_sec <= t_end:
-            window_end = current_time + window_width_sec
-            window_mask = (t >= current_time) & (t <= window_end)
+            if np.sum(window_mask) < 2:
+                continue
 
-            if np.sum(window_mask) >= 2:
-                window_av = av[window_mask]
-                sign_changes = np.sum(np.diff(np.sign(window_av)) != 0)
-                frequency = float(sign_changes) / window_width_sec
+            window_av = av[window_mask]
+            switch_count = _count_sign_switches(window_av)
 
-                window_center_time = float(current_time + window_width_sec / 2.0)
-                w_times.append(window_center_time)
-                w_freqs.append(frequency)
-
-            current_time += window_shift_sec
+            w_times.append(window_start + window_width_sec / 2.0)
+            w_counts.append(float(switch_count))
 
         out_time.append(w_times)
-        out_freq.append(w_freqs)
+        out_count.append(w_counts)
 
-    return out_time, out_freq
+    return out_time, out_count
 
 
 def detect_rise_index(
@@ -1713,21 +1715,87 @@ def run_pre_rise_fluctuation(
     return valid_indices
 
 
-def add_rise_time_to_results(results: List[Dict[str, float]], time_list: Sequence[Sequence[float]]) -> None:
+def add_rise_time_to_results(
+    day: str,
+    results: List[Dict[str, float]],
+    time_list: Sequence[Sequence[float]],
+) -> None:
+    flag_use_manual_rise_time = param.get_flag_use_manual_rise_time(day, default_flag=False)
+
+    if flag_use_manual_rise_time:
+        manual_rise_time_list = param.get_manual_rise_time_sec_config(day)
+
+        if len(manual_rise_time_list) != len(results):
+            raise ValueError(
+                "Length mismatch: manual_rise_time_sec must have the same number of values "
+                f"as samples. manual={len(manual_rise_time_list)}, results={len(results)}"
+            )
+
+        for i, result in enumerate(results):
+            manual_rise_time = float(manual_rise_time_list[i])
+
+            if i >= len(time_list):
+                result["rise_index"] = np.nan
+                result["rise_time"] = manual_rise_time
+                continue
+
+            t = np.asarray(time_list[i], dtype=float)
+
+            if t.size == 0:
+                result["rise_index"] = np.nan
+                result["rise_time"] = manual_rise_time
+                continue
+
+            finite_idx = np.flatnonzero(np.isfinite(t))
+            if finite_idx.size == 0:
+                result["rise_index"] = np.nan
+                result["rise_time"] = manual_rise_time
+                continue
+
+            finite_t = t[finite_idx]
+            insert_pos = int(np.searchsorted(finite_t, manual_rise_time, side="left"))
+
+            if insert_pos >= finite_idx.size:
+                rise_idx = len(t)
+            else:
+                rise_idx = int(finite_idx[insert_pos])
+
+            result["rise_index"] = float(rise_idx)
+            result["rise_time"] = manual_rise_time
+            result["baseline_mean"] = np.nan
+            result["baseline_std"] = np.nan
+            result["threshold"] = np.nan
+            result["num_frames"] = float(len(t))
+            result["sample_no"] = float(i + 1)
+
+        return
+
     for i, result in enumerate(results):
+        if i >= len(time_list):
+            result["rise_time"] = np.nan
+            continue
+
+        t = np.asarray(time_list[i], dtype=float)
+        if t.size == 0:
+            result["rise_time"] = np.nan
+            continue
+
         rise_index = result.get("rise_index", np.nan)
-        if i >= len(time_list) or not np.isfinite(rise_index):
+        if rise_index is None or not np.isfinite(rise_index):
             result["rise_time"] = np.nan
             continue
-        time_arr = np.asarray(time_list[i], dtype=float)
-        if time_arr.size == 0:
+
+        rise_idx = int(rise_index)
+        if rise_idx < 0:
             result["rise_time"] = np.nan
             continue
-        idx = _normalize_rise_index(float(rise_index), time_arr.size)
-        if idx >= time_arr.size:
-            result["rise_time"] = np.nan
-        else:
-            result["rise_time"] = float(time_arr[idx])
+        if rise_idx >= len(t):
+            finite_t = t[np.isfinite(t)]
+            result["rise_time"] = float(finite_t[-1]) if finite_t.size > 0 else np.nan
+            continue
+
+        rise_time = t[rise_idx]
+        result["rise_time"] = float(rise_time) if np.isfinite(rise_time) else np.nan
 
 
 def ensure_time_list(day: str) -> List[List[float]]:

--- a/utils/functions/save2csv.py
+++ b/utils/functions/save2csv.py
@@ -1,6 +1,7 @@
 import csv
 import os
 from itertools import zip_longest
+from typing import Sequence
 
 import pandas as pd
 

--- a/utils/functions/save2csv.py
+++ b/utils/functions/save2csv.py
@@ -181,9 +181,9 @@ def save_angular_velocity_switching_frequency(
     sample_num = min(len(time_list), len(frequency_list))
     save_dir = f"{param.save_dir_bef}/{day}/repellent_response/03_post_rise_analysis/angular_velocity"
     os.makedirs(save_dir, exist_ok=True)
-    
+
     csv_path = f"{save_dir}/switching_frequency.csv"
-    
+
     data = {}
     for i in range(sample_num):
         t_arr = pd.Series(time_list[i], dtype="float64")
@@ -191,5 +191,5 @@ def save_angular_velocity_switching_frequency(
         n = min(len(t_arr), len(f_arr))
         data[f"No.{i+1}_time"] = t_arr.iloc[:n].reset_index(drop=True)
         data[f"No.{i+1}_frequency"] = f_arr.iloc[:n].reset_index(drop=True)
-    
+
     pd.DataFrame(data).to_csv(csv_path, index=False)

--- a/utils/functions/save2csv.py
+++ b/utils/functions/save2csv.py
@@ -169,3 +169,26 @@ def save_repellent_time_list(time_list, day):
     for i in range(len(time_list)):
         data[f"No.{i+1}"] = pd.Series(time_list[i], dtype="float64")
     pd.DataFrame(data).to_csv(csv_save_dir, index=False)
+
+
+def save_angular_velocity_switching_frequency(
+    time_list: Sequence[Sequence[float]],
+    frequency_list: Sequence[Sequence[float]],
+    day: str,
+) -> None:
+    """Save angular velocity switching frequency to CSV."""
+    sample_num = min(len(time_list), len(frequency_list))
+    save_dir = f"{param.save_dir_bef}/{day}/repellent_response/03_post_rise_analysis/angular_velocity"
+    os.makedirs(save_dir, exist_ok=True)
+    
+    csv_path = f"{save_dir}/switching_frequency.csv"
+    
+    data = {}
+    for i in range(sample_num):
+        t_arr = pd.Series(time_list[i], dtype="float64")
+        f_arr = pd.Series(frequency_list[i], dtype="float64")
+        n = min(len(t_arr), len(f_arr))
+        data[f"No.{i+1}_time"] = t_arr.iloc[:n].reset_index(drop=True)
+        data[f"No.{i+1}_frequency"] = f_arr.iloc[:n].reset_index(drop=True)
+    
+    pd.DataFrame(data).to_csv(csv_path, index=False)

--- a/utils/functions/save2csv.py
+++ b/utils/functions/save2csv.py
@@ -172,24 +172,24 @@ def save_repellent_time_list(time_list, day):
     pd.DataFrame(data).to_csv(csv_save_dir, index=False)
 
 
-def save_angular_velocity_switching_frequency(
+def save_angular_velocity_switching_count(
     time_list: Sequence[Sequence[float]],
-    frequency_list: Sequence[Sequence[float]],
+    count_list: Sequence[Sequence[float]],
     day: str,
 ) -> None:
-    """Save angular velocity switching frequency to CSV."""
-    sample_num = min(len(time_list), len(frequency_list))
-    save_dir = f"{param.save_dir_bef}/{day}/repellent_response/03_post_rise_analysis/angular_velocity"
+    """Save angular velocity switching count to CSV."""
+    sample_num = min(len(time_list), len(count_list))
+    save_dir = f"{param.save_dir_bef}/{day}/repellent_response/00_all_rotational_analysis/angular_velocity"
     os.makedirs(save_dir, exist_ok=True)
 
-    csv_path = f"{save_dir}/switching_frequency.csv"
+    csv_path = f"{save_dir}/switching_count.csv"
 
     data = {}
     for i in range(sample_num):
         t_arr = pd.Series(time_list[i], dtype="float64")
-        f_arr = pd.Series(frequency_list[i], dtype="float64")
-        n = min(len(t_arr), len(f_arr))
+        c_arr = pd.Series(count_list[i], dtype="float64")
+        n = min(len(t_arr), len(c_arr))
         data[f"No.{i+1}_time"] = t_arr.iloc[:n].reset_index(drop=True)
-        data[f"No.{i+1}_frequency"] = f_arr.iloc[:n].reset_index(drop=True)
+        data[f"No.{i+1}_count"] = c_arr.iloc[:n].reset_index(drop=True)
 
     pd.DataFrame(data).to_csv(csv_path, index=False)

--- a/utils/param.py
+++ b/utils/param.py
@@ -19,6 +19,17 @@ def get_flag_use_tiff_log(day):
     return flag_use_tiff_log
 
 
+def get_flag_use_brightness_data(day, default_flag=False):
+    config_dir = f"{input_dir_bef}/{day}/config.ini"
+    config = configparser.ConfigParser()
+    config.read(config_dir)
+
+    try:
+        return config.getboolean("RepellentResponse", "flag_use_brightness_data")
+    except (configparser.NoSectionError, configparser.NoOptionError, ValueError):
+        return bool(default_flag)
+
+
 def get_config(day):
     config_dir = f"{input_dir_bef}/{day}/config.ini"
     config = configparser.ConfigParser()

--- a/utils/param.py
+++ b/utils/param.py
@@ -39,27 +39,6 @@ def get_flag_use_brightness_data(day, default_flag=False):
         return bool(default_flag)
 
 
-def get_post_rise_center_mode(day, default_mode=2):
-    config = _read_config(day)
-    section = "RepellentResponse"
-    option = "post_rise_center_mode"
-
-    if not config.has_section(section):
-        return int(default_mode)
-    if not config.has_option(section, option):
-        return int(default_mode)
-
-    raw_value = config.get(section, option, fallback=str(default_mode))
-    try:
-        mode = int(raw_value)
-    except (ValueError, TypeError):
-        return int(default_mode)
-
-    if mode not in (1, 2, 3):
-        return int(default_mode)
-    return mode
-
-
 def get_config(day):
     config = _read_config(day)
     flag_use_tiff_log = get_flag_use_tiff_log(day)
@@ -203,6 +182,12 @@ av_switching_window_shift_sec = 0.5  # Window shift step in seconds
 
 # Background ROI Configuration (repellent response)
 bg_roi_offset_um_downward = 10.0  # Downward offset from centroid in micrometers
+
+# Repellent response post-rise center strategy.
+# 1: use rolling mean of the raw coordinates after rise
+# 2: use rolling median of the raw coordinates after rise
+# 3: use the constant post-rise mean center
+post_rise_center_mode = 2
 
 # fluctuation analysis
 # SD_window_width_list = [0.1, 0.5, 1.0]

--- a/utils/param.py
+++ b/utils/param.py
@@ -87,6 +87,25 @@ def get_tiffinfo_config(day):
     return items
 
 
+def get_flag_use_brightness_data(day, default_flag=False):
+    config_dir = f"{input_dir_bef}/{day}/config.ini"
+    config = configparser.ConfigParser()
+    config.read(config_dir)
+
+    section = "RepellentResponse"
+    option = "flag_use_brightness_data"
+
+    if not config.has_section(section):
+        return default_flag
+    if not config.has_option(section, option):
+        return default_flag
+
+    try:
+        return config.getboolean(section, option)
+    except ValueError:
+        return default_flag
+
+
 # rotational analysis
 ## Determine the angle by the direction of the cell.
 # flag_get_angle_with_cell_direcetion = True

--- a/utils/param.py
+++ b/utils/param.py
@@ -121,6 +121,13 @@ min_ref_av_num = 10  # Average
 ## Switching
 flag_eval_switching_with_averaged_av = False
 
+# Angular Velocity Switching Frequency Analysis (post-rise)
+av_switching_window_width_sec = 2.0  # Window width in seconds
+av_switching_window_shift_sec = 0.5   # Window shift step in seconds
+
+# Background ROI Configuration (repellent response)
+bg_roi_offset_um_downward = 10.0  # Downward offset from centroid in micrometers
+
 # fluctuation analysis
 # SD_window_width_list = [0.1, 0.5, 1.0]
 SD_window_width_list = [0.1, 0.2, 0.5, 1.0, 1.5, 2.0]

--- a/utils/param.py
+++ b/utils/param.py
@@ -153,7 +153,7 @@ flag_eval_switching_with_averaged_av = False
 
 # Angular Velocity Switching Frequency Analysis (post-rise)
 av_switching_window_width_sec = 2.0  # Window width in seconds
-av_switching_window_shift_sec = 0.5   # Window shift step in seconds
+av_switching_window_shift_sec = 0.5  # Window shift step in seconds
 
 # Background ROI Configuration (repellent response)
 bg_roi_offset_um_downward = 10.0  # Downward offset from centroid in micrometers

--- a/utils/param.py
+++ b/utils/param.py
@@ -9,32 +9,59 @@ input_dir_bef = f"{curr_dir}/data"
 save_dir_bef = f"{curr_dir}/outputs"
 
 
-def get_flag_use_tiff_log(day):
+def _read_config(day):
     config_dir = f"{input_dir_bef}/{day}/config.ini"
     config = configparser.ConfigParser()
     config.read(config_dir)
+    return config
 
+
+def get_flag_use_tiff_log(day):
+    config = _read_config(day)
     flag_use_tiff_log = config.getboolean("Settings", "flag_use_tiff_log")
 
     return flag_use_tiff_log
 
 
 def get_flag_use_brightness_data(day, default_flag=False):
-    config_dir = f"{input_dir_bef}/{day}/config.ini"
-    config = configparser.ConfigParser()
-    config.read(config_dir)
+    config = _read_config(day)
+    section = "RepellentResponse"
+    option = "flag_use_brightness_data"
+
+    if not config.has_section(section):
+        return bool(default_flag)
+    if not config.has_option(section, option):
+        return bool(default_flag)
 
     try:
-        return config.getboolean("RepellentResponse", "flag_use_brightness_data")
-    except (configparser.NoSectionError, configparser.NoOptionError, ValueError):
+        return config.getboolean(section, option)
+    except ValueError:
         return bool(default_flag)
 
 
-def get_config(day):
-    config_dir = f"{input_dir_bef}/{day}/config.ini"
-    config = configparser.ConfigParser()
-    config.read(config_dir)
+def get_post_rise_center_mode(day, default_mode=2):
+    config = _read_config(day)
+    section = "RepellentResponse"
+    option = "post_rise_center_mode"
 
+    if not config.has_section(section):
+        return int(default_mode)
+    if not config.has_option(section, option):
+        return int(default_mode)
+
+    raw_value = config.get(section, option, fallback=str(default_mode))
+    try:
+        mode = int(raw_value)
+    except (ValueError, TypeError):
+        return int(default_mode)
+
+    if mode not in (1, 2, 3):
+        return int(default_mode)
+    return mode
+
+
+def get_config(day):
+    config = _read_config(day)
     flag_use_tiff_log = get_flag_use_tiff_log(day)
     sample_num = config.getint("Settings", "sample_num")
     # Frame Rate, Total Time
@@ -63,9 +90,7 @@ def get_config(day):
 
 
 def get_px2um_config(day):
-    config_dir = f"{input_dir_bef}/{day}/config.ini"
-    config = configparser.ConfigParser()
-    config.read(config_dir)
+    config = _read_config(day)
     try:
         px2um_x = config.getfloat("Settings", "px2um_x")
     except (ValueError, TypeError):
@@ -78,38 +103,15 @@ def get_px2um_config(day):
 
 
 def get_tiffinfo_config(day):
-    config_dir = f"{input_dir_bef}/{day}/config.ini"
-    config = configparser.ConfigParser()
-    config.read(config_dir)
+    config = _read_config(day)
 
     items = config["Tiff_info"]["tiff_data"].split(", ")
 
     return items
 
 
-def get_flag_use_brightness_data(day, default_flag=False):
-    config_dir = f"{input_dir_bef}/{day}/config.ini"
-    config = configparser.ConfigParser()
-    config.read(config_dir)
-
-    section = "RepellentResponse"
-    option = "flag_use_brightness_data"
-
-    if not config.has_section(section):
-        return default_flag
-    if not config.has_option(section, option):
-        return default_flag
-
-    try:
-        return config.getboolean(section, option)
-    except ValueError:
-        return default_flag
-
-
 def get_flag_use_manual_rise_time(day, default_flag=False):
-    config_dir = f"{input_dir_bef}/{day}/config.ini"
-    config = configparser.ConfigParser()
-    config.read(config_dir)
+    config = _read_config(day)
 
     section = "RepellentResponse"
     option = "flag_use_manual_rise_time"
@@ -126,9 +128,7 @@ def get_flag_use_manual_rise_time(day, default_flag=False):
 
 
 def get_manual_rise_time_sec_config(day):
-    config_dir = f"{input_dir_bef}/{day}/config.ini"
-    config = configparser.ConfigParser()
-    config.read(config_dir)
+    config = _read_config(day)
 
     section = "RepellentResponse"
     option = "manual_rise_time_sec"

--- a/utils/param.py
+++ b/utils/param.py
@@ -106,6 +106,52 @@ def get_flag_use_brightness_data(day, default_flag=False):
         return default_flag
 
 
+def get_flag_use_manual_rise_time(day, default_flag=False):
+    config_dir = f"{input_dir_bef}/{day}/config.ini"
+    config = configparser.ConfigParser()
+    config.read(config_dir)
+
+    section = "RepellentResponse"
+    option = "flag_use_manual_rise_time"
+
+    if not config.has_section(section):
+        return default_flag
+    if not config.has_option(section, option):
+        return default_flag
+
+    try:
+        return config.getboolean(section, option)
+    except ValueError:
+        return default_flag
+
+
+def get_manual_rise_time_sec_config(day):
+    config_dir = f"{input_dir_bef}/{day}/config.ini"
+    config = configparser.ConfigParser()
+    config.read(config_dir)
+
+    section = "RepellentResponse"
+    option = "manual_rise_time_sec"
+
+    if not config.has_section(section):
+        return []
+    if not config.has_option(section, option):
+        return []
+
+    raw_value = config.get(section, option, fallback="").strip()
+    if raw_value == "":
+        return []
+
+    values = []
+    for item in raw_value.split(","):
+        item = item.strip()
+        if item == "":
+            continue
+        values.append(float(item))
+
+    return values
+
+
 # rotational analysis
 ## Determine the angle by the direction of the cell.
 # flag_get_angle_with_cell_direcetion = True

--- a/utils/param.py
+++ b/utils/param.py
@@ -126,7 +126,10 @@ def get_manual_rise_time_sec_config(day):
         item = item.strip()
         if item == "":
             continue
-        values.append(float(item))
+        try:
+            values.append(float(item))
+        except ValueError as exc:
+            raise ValueError(f"Invalid float in {section}.{option}: '{item}'") from exc
 
     return values
 


### PR DESCRIPTION
## Summary
- Refactored repellent-response configuration handling so `post_rise_center_mode` is defined in `utils/param.py` as a constant instead of being read from `config.ini`.
- Kept `flag_use_brightness_data` as a config-driven flag, and made `brightness_data` required when that flag is enabled.
- Hardened the repellent-response pipeline against empty FFT inputs, degenerate ellipse fits, and log-scaled plots with no positive values.
- Added CLI support to run `04_repellent_response_analysis.py` with an explicit `--post-rise-center-mode` and optional output suffix.

## Validation
- `ruff check .`
- `mypy .`
- `python3 scripts/04_repellent_response_analysis.py --day repellent-response/23 --post-rise-center-mode 1 --output-suffix mode1_reuse_final`
- `python3 scripts/04_repellent_response_analysis.py --day repellent-response/23 --post-rise-center-mode 2 --output-suffix mode2_reuse_final`
- `python3 scripts/04_repellent_response_analysis.py --day repellent-response/23 --post-rise-center-mode 3 --output-suffix mode3_fix`

## Outputs
- Mode 1: `outputs/mode1_reuse_final/repellent-response/23/repellent_response/`
- Mode 2: `outputs/mode2_reuse_final/repellent-response/23/repellent_response/`
- Mode 3: `outputs/mode3_fix/repellent-response/23/repellent_response/`

## Notes
- If `flag_use_brightness_data = True`, `data/<day>/brightness_data/` must exist and contain the per-sample CSV files.